### PR TITLE
Move ros-workspace test to catkin build scripts.

### DIFF
--- a/vinca/templates/bld_ament_cmake.bat.in
+++ b/vinca/templates/bld_ament_cmake.bat.in
@@ -39,12 +39,3 @@ if errorlevel 1 exit 1
 
 cmake --build . --config Release --target install
 if errorlevel 1 exit 1
-
-if "%PKG_NAME%" == "ros-@(ros_distro)-ros-workspace" (
-    :: Copy the [de]activate scripts to %PREFIX%\etc\conda\[de]activate.d.
-    :: This will allow them to be run on environment activation.
-    for %%F in (activate deactivate) DO (
-        if not exist %PREFIX%\etc\conda\%%F.d mkdir %PREFIX%\etc\conda\%%F.d
-        copy %RECIPE_DIR%\%%F.bat %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
-    )
-)

--- a/vinca/templates/bld_catkin.bat.in
+++ b/vinca/templates/bld_catkin.bat.in
@@ -59,3 +59,12 @@ if "%PKG_NAME%" == "ros-@(ros_distro)-catkin" (
         copy %RECIPE_DIR%\%%F.bat %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
     )
 )
+
+if "%PKG_NAME%" == "ros-@(ros_distro)-ros-workspace" (
+    :: Copy the [de]activate scripts to %PREFIX%\etc\conda\[de]activate.d.
+    :: This will allow them to be run on environment activation.
+    for %%F in (activate deactivate) DO (
+        if not exist %PREFIX%\etc\conda\%%F.d mkdir %PREFIX%\etc\conda\%%F.d
+        copy %RECIPE_DIR%\%%F.bat %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
+    )
+)

--- a/vinca/templates/build_ament_cmake.sh.in
+++ b/vinca/templates/build_ament_cmake.sh.in
@@ -30,13 +30,3 @@ cmake \
     $SRC_DIR/$PKG_NAME/src/work
 
 cmake --build . --config Release --target install
-
-if [ "${PKG_NAME}" == "ros-@(ros_distro)-ros-workspace" ]; then
-    # Copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.
-    # This will allow them to be run on environment activation.
-    for CHANGE in "activate" "deactivate"
-    do
-        mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
-        cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
-    done
-fi

--- a/vinca/templates/build_catkin.sh.in
+++ b/vinca/templates/build_catkin.sh.in
@@ -89,3 +89,13 @@ if [ "${PKG_NAME}" == "ros-@(ros_distro)-catkin" ]; then
        done
    fi
 fi
+
+if [ "${PKG_NAME}" == "ros-@(ros_distro)-ros-workspace" ]; then
+    # Copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.
+    # This will allow them to be run on environment activation.
+    for CHANGE in "activate" "deactivate"
+    do
+        mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+        cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
+    done
+fi


### PR DESCRIPTION
The ros_workspace package is a plain CMake (as opposed to an ament_cmake) package and thus uses the catkin build scripts rather than the ament_cmake build scripts.

By moving this test I'm able to locally generate scripts with vinca that add activation and deactivation scripts.

```
❯ tar tf /home/steven/mambaforge/conda-bld/linux-64/ros-galactic-ros-workspace-1.0.2-py38he9ab703_99.tar.bz2 | sort |grep '^etc'         (base)
etc/conda/activate.d/ros-galactic-ros-workspace_activate.sh
etc/conda/deactivate.d/ros-galactic-ros-workspace_deactivate.sh
```