### PR TITLE
use cached repodata.json

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
   empy >=3.3.4
   requests >=2.24.0
   networkx >=2.5
+  rich >=10
 packages = find:
 zip_safe = false
 

--- a/vinca/config.py
+++ b/vinca/config.py
@@ -1,3 +1,4 @@
 selected_platform = None
 ros_distro = None
 skip_testing = None
+parsed_args = None

--- a/vinca/main.py
+++ b/vinca/main.py
@@ -21,8 +21,6 @@ from vinca.utils import get_repodata
 unsatisfied_deps = set()
 distro = None
 
-parsed_args = None
-
 
 def ensure_list(obj):
     if not obj:
@@ -32,8 +30,8 @@ def ensure_list(obj):
 
 
 def get_conda_subdir():
-    if parsed_args.platform:
-        return parsed_args.platform
+    if config.parsed_args.platform:
+        return config.parsed_args.platform
 
     sys_platform = sys.platform
     machine = platform.machine()
@@ -120,8 +118,8 @@ def parse_command_line(argv):
         help="The conda platform to check existing recipes for.",
     )
     arguments = parser.parse_args(argv[1:])
-    global parsed_args, selected_platform
-    parsed_args = arguments
+    global selected_platform
+    config.parsed_args = arguments
     config.selected_platform = get_conda_subdir()
     return arguments
 
@@ -191,6 +189,10 @@ def read_vinca_yaml(filepath):
 
     config.ros_distro = vinca_conf["ros_distro"]
     config.skip_testing = vinca_conf.get("skip_testing", True)
+
+    vinca_conf["_conda_indexes"] = get_conda_index(
+        vinca_conf, os.path.dirname(filepath)
+    )
 
     return vinca_conf
 
@@ -769,7 +771,6 @@ def main():
     base_dir = os.path.abspath(arguments.dir)
     vinca_yaml = os.path.join(base_dir, "vinca.yaml")
     vinca_conf = read_vinca_yaml(vinca_yaml)
-    vinca_conf["_conda_indexes"] = get_conda_index(vinca_conf, base_dir)
 
     from .template import generate_bld_ament_cmake
     from .template import generate_bld_ament_python

--- a/vinca/migrate.py
+++ b/vinca/migrate.py
@@ -2,13 +2,12 @@ import yaml
 import sys
 import os
 import argparse
-import requests
 import re
 import networkx as nx
 import subprocess
 import shutil
 import ruamel.yaml
-
+from .utils import get_repodata
 
 from vinca.distro import Distro
 
@@ -36,7 +35,7 @@ def to_ros_name(distro, pkg_name):
 
 
 def create_migration_instructions(arch, packages_to_migrate, trigger_branch):
-    url = f"https://conda.anaconda.org/robostack/{arch}/repodata.json"
+    url = "https://conda.anaconda.org/robostack/"
 
     yaml = ruamel.yaml.YAML()
     with open("vinca.yaml", "r") as fi:
@@ -46,9 +45,8 @@ def create_migration_instructions(arch, packages_to_migrate, trigger_branch):
     distro_version = vinca_conf["ros_distro"]
     ros_prefix = f"ros-{distro_version}"
 
-    print("URL: ", url)
-    # return
-    repodata = requests.get(url).json()
+    repodata = get_repodata(url, arch)
+
     packages = repodata["packages"]
     to_migrate = set()
     ros_pkgs = set()


### PR DESCRIPTION
@Tobias-Fischer I am continuing here.

The remaining problem is about the graph sorting. 

Basically we have a subset of packages that need to be migrated. However, if we only topologically sort the packages that need to be migrated then we don't end up with the proper sorting. We need to sort _the entire graph_ and then use that to find the right order to build the packages in. 

For that we could use either the repodata.json or the rosdistro data. I think I'd like to use the repodata.json info for now, and see if that works out.