### PR TITLE
Fix rosdep key for setuptools

### DIFF
--- a/vinca/main.py
+++ b/vinca/main.py
@@ -261,7 +261,7 @@ def generate_output(pkg_shortname, vinca_conf, distro, version, all_pkgs=None):
             "sel(win)": "bld_ament_python.bat",
             "sel(unix)": "build_ament_python.sh",
         }
-        resolved_setuptools = resolve_pkgname("setuptools", vinca_conf, distro)
+        resolved_setuptools = resolve_pkgname("python-setuptools", vinca_conf, distro)
         output["requirements"]["host"].extend(resolved_setuptools)
     else:
         return None


### PR DESCRIPTION
The rosdep key for setuptools used in the various RoboStack distros is not `setuptools` (that get resolved to an empty list), but instead of `python-setuptools` or `python3-setuptools`, see:
* https://github.com/RoboStack/ros-galactic/blob/eb10e79666b199c00683a51b0ac6938e70dfbad5/robostack.yaml#L576 