### PR TITLE
bld_ament_python.bat.in: Substitute _LIBRARY_PREFIX_PATH with LIBRARY_PREFIX

### DIFF
--- a/vinca/templates/bld_ament_python.bat.in
+++ b/vinca/templates/bld_ament_python.bat.in
@@ -8,7 +8,7 @@ pushd %SRC_DIR%\%PKG_NAME%\src\work
 
 :: If there is a setup.cfg that contains install-scripts then we should not
 :: set it here
-set "INSTALL_SCRIPTS_ARG=--install-scripts=%_LIBRARY_PREFIX_PATH%\bin"
+set "INSTALL_SCRIPTS_ARG=--install-scripts=%LIBRARY_PREFIX%\bin"
 findstr install[-_]scripts setup.cfg
 if "%errorlevel%" == "0" (
   set INSTALL_SCRIPTS_ARG=


### PR DESCRIPTION
`_LIBRARY_PREFIX_PATH` was a variable defined before https://github.com/RoboStack/vinca/pull/29, but it is not defined anymore. 