### PR TITLE
Switch boa branch from master to main

### DIFF
--- a/vinca/azure_templates/win_build.bat
+++ b/vinca/azure_templates/win_build.bat
@@ -13,7 +13,7 @@ reg add HKLM\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t 
 
 :: conda remove --force m2-git
 
-C:\\Miniconda\\python.exe -m pip install git+https://github.com/mamba-org/boa.git@master
+C:\\Miniconda\\python.exe -m pip install git+https://github.com/mamba-org/boa.git@main
 if errorlevel 1 exit 1
 
 for %%X in (%CURRENT_RECIPES%) do (


### PR DESCRIPTION
Boa (https://github.com/mamba-org/boa.git) is now using main instead of master.