### PR TITLE
In Windows builds explicitly set CL environment variable to `/DROS_BUILD_SHARED_LIBS=1`

### DIFF
--- a/vinca/templates/bld_catkin.bat.in
+++ b/vinca/templates/bld_catkin.bat.in
@@ -6,7 +6,7 @@ set "PYTHONPATH=%LIBRARY_PREFIX%\lib\site-packages;%SP_DIR%"
 :: MSVC is preferred.
 set CC=cl.exe
 set CXX=cl.exe
-https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables?view=msvc-170
+
 :: ROS_BUILD_SHARED_LIBS is always defined in CMake by catkin
 :: if ROS (1) is build as shared library . However, some packages are not
 :: passing compilation flags from CMake to other build systems (such as qmake),

--- a/vinca/templates/bld_catkin.bat.in
+++ b/vinca/templates/bld_catkin.bat.in
@@ -6,6 +6,13 @@ set "PYTHONPATH=%LIBRARY_PREFIX%\lib\site-packages;%SP_DIR%"
 :: MSVC is preferred.
 set CC=cl.exe
 set CXX=cl.exe
+https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables?view=msvc-170
+:: ROS_BUILD_SHARED_LIBS is always defined in CMake by catkin
+:: if ROS (1) is build as shared library . However, some packages are not
+:: passing compilation flags from CMake to other build systems (such as qmake),
+:: so we enable it explicitly via the CL environment variable, see
+:: https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables?view=msvc-170
+set CL=/DROS_BUILD_SHARED_LIBS=1
 
 set "CATKIN_BUILD_BINARY_PACKAGE_ARGS=-DCATKIN_BUILD_BINARY_PACKAGE=1"
 if "%PKG_NAME%" == "ros-@(ros_distro)-catkin" (

--- a/vinca/templates/bld_catkin_merge.bat.in
+++ b/vinca/templates/bld_catkin_merge.bat.in
@@ -6,6 +6,13 @@ setlocal
 set CC=cl.exe
 set CXX=cl.exe
 
+:: ROS_BUILD_SHARED_LIBS is always defined in CMake by catkin
+:: if ROS (1) is build as shared library . However, some packages are not
+:: passing compilation flags from CMake to other build systems (such as qmake),
+:: so we enable it explicitly via the CL environment variable, see
+:: https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables?view=msvc-170
+set CL=/DROS_BUILD_SHARED_LIBS=1
+
 set CATKIN_MAKE_ISOLATED=src\ros-@(ros_distro)-catkin\bin\catkin_make_isolated
 set CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH:\=/%
 


### PR DESCRIPTION
ROS_BUILD_SHARED_LIBS is always defined in CMake by catkin, if ROS (1) is build as shared library . However, some packages are not  passing compilation flags from CMake to other build systems (such as qmake), so we enable it explicitly via the CL environment variable, see https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables?view=msvc-170 .

I could only define this if the package name is `ros-noetic-qt-gui-cpp`, but I tought it was useful to have this also for other packages for similar problems, and anyhow it should not be problematic for other packages.

Fix https://github.com/RoboStack/ros-noetic/issues/331 .