### PR TITLE
Fix binary install location

### DIFF
--- a/vinca/templates/build_ament_python.sh.in
+++ b/vinca/templates/build_ament_python.sh.in
@@ -2,4 +2,15 @@
 # DO NOT EDIT!
 
 pushd $SRC_DIR/$PKG_NAME/src/work
-$PYTHON -m pip install . --no-deps -vvv
+
+# If there is a setup.cfg that contains install-scripts then we should not set it here
+grep -q "install[-_]scripts" setup.cfg
+if [ $? -eq 0 ]; then
+  INSTALL_SCRIPTS_ARG=""
+else
+  INSTALL_SCRIPTS_ARG="--install-scripts=$PREFIX/lib/$PKG_NAME"
+fi
+
+# Old: This installs the binaries in the wrong location - see https://github.com/RoboStack/ros-humble/issues/41
+# $PYTHON -m pip install . --no-deps -vvv
+$PYTHON setup.py install --prefix="$PREFIX" --install-lib="$SP_DIR" $INSTALL_SCRIPTS_ARG

--- a/vinca/templates/build_ament_python.sh.in
+++ b/vinca/templates/build_ament_python.sh.in
@@ -8,7 +8,11 @@ grep -q "install[-_]scripts" setup.cfg
 if [ $? -eq 0 ]; then
   INSTALL_SCRIPTS_ARG=""
 else
-  INSTALL_SCRIPTS_ARG="--install-scripts=$PREFIX/lib/$PKG_NAME"
+  # this is not quite what we want as PKG_NAME contains ros-humble- ..
+  # INSTALL_SCRIPTS_ARG="--install-scripts=$PREFIX/lib/$PKG_NAME"
+  # therefore for now throw an error as packages should have a setup.cfg
+  echo "This package is missing a setup.cfg, stopping."
+  exit 1
 fi
 
 # Old: This installs the binaries in the wrong location - see https://github.com/RoboStack/ros-humble/issues/41


### PR DESCRIPTION
Hi @traversaro,

This should fix https://github.com/RoboStack/ros-humble/issues/41

It definitely fixes the demo_nodes_py issue that you have referred to in that issue. Are you aware of any packages that do not have a setup.cfg, so we can test this case as well?