### PR TITLE
Fix AMENT_PYTHON_EXECUTABLE location on Windows

### DIFF
--- a/vinca/templates/activate.bat.in
+++ b/vinca/templates/activate.bat.in
@@ -12,4 +12,4 @@
 @@set "ROS_OS_OVERRIDE=conda:win64"
 @@set "ROS_ETC_DIR=%CONDA_PREFIX%\Library\etc\ros"
 @@set "AMENT_PREFIX_PATH=%CONDA_PREFIX%\Library"
-@@set "AMENT_PYTHON_EXECUTABLE=%CONDA_PREFIX%\Library\python.exe"
+@@set "AMENT_PYTHON_EXECUTABLE=%CONDA_PREFIX%\python.exe"

--- a/vinca/templates/activate.ps1.in
+++ b/vinca/templates/activate.ps1.in
@@ -13,4 +13,4 @@ $Env:PYTHONHOME=''
 $Env:ROS_OS_OVERRIDE='conda:win64'
 $Env:ROS_ETC_DIR="${env:CONDA_PREFIX}\Library\etc\ros"
 $Env:AMENT_PREFIX_PATH="${env:CONDA_PREFIX}\Library"
-$Env:AMENT_PYTHON_EXECUTABLE="${env:CONDA_PREFIX}\Library\python.exe"
+$Env:AMENT_PYTHON_EXECUTABLE="${env:CONDA_PREFIX}\python.exe"


### PR DESCRIPTION
Fix https://github.com/RoboStack/ros-humble/issues/100 (after a re-build of the appropriate package)
Related to https://github.com/RoboStack/ros-galactic/issues/53