### PR TITLE
Fix installation of Python scripts in %CONDA_PREFIX%\Library\bin

### DIFF
--- a/vinca/templates/bld_ament_python.bat.in
+++ b/vinca/templates/bld_ament_python.bat.in
@@ -11,11 +11,10 @@ findstr install[-_]scripts setup.cfg
 if "%errorlevel%" == "0" (
     %PYTHON% -m pip install . --no-deps -vvv
 ) else (
-    set "INSTALL_SCRIPTS_ARG=--install-scripts=%LIBRARY_PREFIX%\bin"
     %PYTHON% setup.py install --single-version-externally-managed --record=files.txt ^
         --prefix=%LIBRARY_PREFIX% ^
         --install-lib=%SP_DIR% ^
-        %INSTALL_SCRIPTS_ARG%
+        --install-scripts=%LIBRARY_PREFIX%\bin
 )
 
 if errorlevel 1 exit 1


### PR DESCRIPTION
I am not sure what was happening, but for some reason the `%INSTALL_SCRIPTS_ARG%` argument was ignored. However, there was no point in having an intermediate variable, and just passing the argument to `python setup.py install` worked fine, so let's just do that.

Fix (together with a rebuilt of all affected packages) https://github.com/RoboStack/ros-humble/issues/135 .