### PR TITLE
Fix check for setup.cfg in build_ament_python.sh.in

### DIFF
--- a/vinca/templates/build_ament_python.sh.in
+++ b/vinca/templates/build_ament_python.sh.in
@@ -4,9 +4,8 @@
 pushd $SRC_DIR/$PKG_NAME/src/work
 
 # If there is a setup.cfg that contains install-scripts then we should not set it here
-grep -q "install[-_]scripts" setup.cfg || true
-result=$?
-if [ $result -eq 0 ]; then
+grep -q "install[-_]scripts" setup.cfg
+if [ $? -eq 0 ]; then
   $PYTHON -m pip install . --no-deps -vvv
 else
   # Remove e.g. ros-humble- from PKG_NAME

--- a/vinca/templates/build_ament_python.sh.in
+++ b/vinca/templates/build_ament_python.sh.in
@@ -4,8 +4,8 @@
 pushd $SRC_DIR/$PKG_NAME/src/work
 
 # If there is a setup.cfg that contains install-scripts then we should not set it here
-result=$?
 grep -q "install[-_]scripts" setup.cfg || true
+result=$?
 if [ $result -eq 0 ]; then
   $PYTHON -m pip install . --no-deps -vvv
 else


### PR DESCRIPTION
Fix https://github.com/RoboStack/vinca/issues/46 by reverting https://github.com/RoboStack/vinca/commit/8be7ab86d554fa0c0e845f900b56b467e3092970 . To actually fix the regression of https://github.com/RoboStack/ros-humble/issues/41 we need a rebuild of affected packages.