### PR TITLE
Fix logic in build_ament_python.sh.in to detect setup.cfg

### DIFF
--- a/vinca/templates/build_ament_python.sh.in
+++ b/vinca/templates/build_ament_python.sh.in
@@ -5,8 +5,6 @@ pushd $SRC_DIR/$PKG_NAME/src/work
 
 # If there is a setup.cfg that contains install-scripts then we should not set it here
 if [ -f setup.cfg ] && grep -q "install[-_]scripts" setup.cfg; then
-  $PYTHON -m pip install . --no-deps -vvv
-else
   # Remove e.g. ros-humble- from PKG_NAME
   PKG_NAME_SHORT=${PKG_NAME#*ros-@(ros_distro)-}
   # Substitute "-" with "_"
@@ -14,4 +12,6 @@ else
   INSTALL_SCRIPTS_ARG="--install-scripts=$PREFIX/lib/$PKG_NAME_SHORT"
   echo "WARNING: setup.cfg not set, will set INSTALL_SCRIPTS_ARG to: $INSTALL_SCRIPTS_ARG"
   $PYTHON setup.py install --prefix="$PREFIX" --install-lib="$SP_DIR" $INSTALL_SCRIPTS_ARG --single-version-externally-managed --record=files.txt
+else
+  $PYTHON -m pip install . --no-deps -vvv
 fi


### PR DESCRIPTION
Fix https://github.com/RoboStack/vinca/issues/46 and also the regression in https://github.com/RoboStack/vinca/pull/48 . I tested it in `ament-copyright` and `demo-nodes-py` and it seems to be working fine.