### PR TITLE
Fix installation of Python nodes that are executed via rosrun on Windows

### DIFF
--- a/vinca/templates/bld_ament_python.bat.in
+++ b/vinca/templates/bld_ament_python.bat.in
@@ -5,11 +5,16 @@ setlocal
 set "PYTHONPATH=%LIBRARY_PREFIX%\lib\site-packages;%SP_DIR%"
 
 pushd %SRC_DIR%\%PKG_NAME%\src\work
+set "PKG_NAME_SHORT=%PKG_NAME:*ros-@(ros_distro)-=%"
+set "PKG_NAME_SHORT=%PKG_NAME_SHORT:-=_%"
 
 :: If there is a setup.cfg that contains install-scripts then use pip to install
 findstr install[-_]scripts setup.cfg
 if "%errorlevel%" == "0" (
-    %PYTHON% -m pip install . --no-deps -vvv
+    %PYTHON% setup.py install --single-version-externally-managed --record=files.txt ^
+        --prefix=%LIBRARY_PREFIX% ^
+        --install-lib=%SP_DIR% ^
+         --install-scripts=%LIBRARY_PREFIX%\lib\%PKG_NAME_SHORT%
 ) else (
     %PYTHON% setup.py install --single-version-externally-managed --record=files.txt ^
         --prefix=%LIBRARY_PREFIX% ^


### PR DESCRIPTION
Hopefully final fix of the series of fixes of `bld_ament_python` scripts. Similarly to the script for `.sh` scripts, this is based on big hack: we assume that the presence of `setup.cfg` means that executables need to be installed in `lib/<shortpkgname>` (see for example https://github.com/ros2/demos/blob/rolling/demo_nodes_py/setup.cfg), while if `setup.cfg` is missing, we assume that python executables need to be installed in `bin` . This is a big hack, that would fail if there is a package that contains a `setup.cfg` contains a option different from `install_scripts`. However, it is the same hack that we used on the *nix side, so it make sense to use it also here.