### PR TITLE
Pass a relative path to PYTHON_INSTALL_DIR in ROS 2

### DIFF
--- a/vinca/templates/bld_ament_cmake.bat.in
+++ b/vinca/templates/bld_ament_cmake.bat.in
@@ -16,7 +16,17 @@ pushd build
 
 :: try to fix long paths issues by using default generator
 set "CMAKE_GENERATOR=Visual Studio %VS_MAJOR% %VS_YEAR%"
-set "SP_DIR_FORWARDSLASHES=%SP_DIR:\=/%"
+
+:: PYTHON_INSTALL_DIR should be a relative path, see
+:: https://github.com/ament/ament_cmake/blob/2.3.2/ament_cmake_python/README.md
+:: So we compute the relative path of %SP_DIR% w.r.t. to LIBRARY_PREFIX,
+:: but it is not trivial to do this in Command Prompt scripting, so let's do it via
+:: python
+
+:: This line is scary, but it basically assigns the output of the command inside (` and `)
+:: to the variable specified after DO SET
+:: The equivalent in bash is PYTHON_INSTALL_DIR=`python -c ...`
+FOR /F "tokens=* USEBACKQ" %%i IN (`python -c "import os;print(os.path.relpath(os.environ['SP_DIR'],os.environ['LIBRARY_PREFIX']))"`) DO SET PYTHON_INSTALL_DIR=%%i
 
 cmake ^
     -G "%CMAKE_GENERATOR%" ^
@@ -30,7 +40,7 @@ cmake ^
     -DBUILD_SHARED_LIBS=ON ^
     -DBUILD_TESTING=OFF ^
     -DCMAKE_OBJECT_PATH_MAX=255 ^
-    -DPYTHON_INSTALL_DIR=%SP_DIR_FORWARDSLASHES% ^
+    -DPYTHON_INSTALL_DIR=%PYTHON_INSTALL_DIR% ^
     %SRC_DIR%\%PKG_NAME%\src\work
 if errorlevel 1 exit 1
 

--- a/vinca/templates/bld_colcon_merge.bat.in
+++ b/vinca/templates/bld_colcon_merge.bat.in
@@ -6,7 +6,16 @@ setlocal
 set CC=cl.exe
 set CXX=cl.exe
 
-set "SP_DIR_FORWARDSLASHES=%SP_DIR:\=/%"
+:: PYTHON_INSTALL_DIR should be a relative path, see
+:: https://github.com/ament/ament_cmake/blob/2.3.2/ament_cmake_python/README.md
+:: So we compute the relative path of %SP_DIR% w.r.t. to LIBRARY_PREFIX,
+:: but it is not trivial to do this in Command Prompt scripting, so let's do it via
+:: python
+
+:: This line is scary, but it basically assigns the output of the command inside (` and `)
+:: to the variable specified after DO SET
+:: The equivalent in bash is PYTHON_INSTALL_DIR=`python -c ...`
+FOR /F "tokens=* USEBACKQ" %%i IN (`python -c "import os;print(os.path.relpath(os.environ['SP_DIR'],os.environ['LIBRARY_PREFIX']))"`) DO SET PYTHON_INSTALL_DIR=%%i
 
 colcon build ^
     --event-handlers console_cohesion+ ^
@@ -16,7 +25,7 @@ colcon build ^
      -G Ninja ^
      -DCMAKE_BUILD_TYPE=Release ^
      -DBUILD_TESTING=OFF ^
-     -DPYTHON_INSTALL_DIR=%SP_DIR_FORWARDSLASHES% ^
+     -DPYTHON_INSTALL_DIR=%PYTHON_INSTALL_DIR% ^
      -DPYTHON_EXECUTABLE=%PYTHON%
 if errorlevel 1 exit 1
 

--- a/vinca/templates/build_ament_cmake.sh.in
+++ b/vinca/templates/build_ament_cmake.sh.in
@@ -44,6 +44,12 @@ if [[ $target_platform =~ linux.* ]]; then
   ln -s $GXX ${BUILD_PREFIX}/bin/g++
 fi;
 
+# PYTHON_INSTALL_DIR should be a relative path, see
+# https://github.com/ament/ament_cmake/blob/2.3.2/ament_cmake_python/README.md
+# So we compute the relative path of $SP_DIR w.r.t. to $PREFIX,
+# but it is not trivial to do this in bash scripting, so let's do it via python
+export PYTHON_INSTALL_DIR=`python -c "import os;print(os.path.relpath(os.environ['SP_DIR'],os.environ['PREFIX']))"`
+
 cmake \
     -G "Ninja" \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
@@ -56,7 +62,7 @@ cmake \
     -DPython3_EXECUTABLE=$PYTHON_EXECUTABLE \
     -DPython3_FIND_STRATEGY=LOCATION \
     -DPKG_CONFIG_EXECUTABLE=$PKG_CONFIG_EXECUTABLE \
-    -DPYTHON_INSTALL_DIR=$SP_DIR \
+    -DPYTHON_INSTALL_DIR=$PYTHON_INSTALL_DIR \
     -DSETUPTOOLS_DEB_LAYOUT=OFF \
     -DCATKIN_SKIP_TESTING=$SKIP_TESTING \
     -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True \


### PR DESCRIPTION
While reviewing https://github.com/RoboStack/ros-humble/issues/138, I noticed that we had a lot of patches due to the fact that in vinca we were passing `PYTHON_INSTALL_DIR` as an absolute path instead of a relative path, as it is required (see https://github.com/ament/ament_cmake/blob/2.3.2/ament_cmake_python/README.md#ament_get_python_install_dir). 

This PR modifies vinca to pass `PYTHON_INSTALL_DIR` as a relative path. Unfortunately, the existing patch in ros-humble are assuming that `PYTHON_INSTALL_DIR` is absolute, so merging this PR without also deleting those patch could create build failures.

For the time being I just opened this PR to collect early feedback, but I am still testing it.