### PR TITLE
Pass --compile-no-warning-as-error to all CMake invocations

### DIFF
--- a/vinca/templates/bld_ament_cmake.bat.in
+++ b/vinca/templates/bld_ament_cmake.bat.in
@@ -31,6 +31,7 @@ cmake ^
     -DBUILD_TESTING=OFF ^
     -DCMAKE_OBJECT_PATH_MAX=255 ^
     -DPYTHON_INSTALL_DIR=%SP_DIR_FORWARDSLASHES% ^
+    --compile-no-warning-as-error ^
     %SRC_DIR%\%PKG_NAME%\src\work
 if errorlevel 1 exit 1
 

--- a/vinca/templates/bld_catkin.bat.in
+++ b/vinca/templates/bld_catkin.bat.in
@@ -30,6 +30,7 @@ set SKIP_TESTING=@(skip_testing)
 
 cmake ^
     -G "Ninja" ^
+    --compile-no-warning-as-error ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=ON ^

--- a/vinca/templates/bld_colcon_merge.bat.in
+++ b/vinca/templates/bld_colcon_merge.bat.in
@@ -13,6 +13,7 @@ colcon build ^
     --merge-install ^
     --install-base %LIBRARY_PREFIX% ^
     --cmake-args ^
+    --compile-no-warning-as-error ^
      -G Ninja ^
      -DCMAKE_BUILD_TYPE=Release ^
      -DBUILD_TESTING=OFF ^

--- a/vinca/templates/build_ament_cmake.sh.in
+++ b/vinca/templates/build_ament_cmake.sh.in
@@ -63,6 +63,7 @@ cmake \
     -DBUILD_SHARED_LIBS=ON  \
     -DBUILD_TESTING=OFF \
     -DCMAKE_OSX_DEPLOYMENT_TARGET=$OSX_DEPLOYMENT_TARGET \
+    --compile-no-warning-as-error \
     $SRC_DIR/$PKG_NAME/src/work
 
 cmake --build . --config Release --target install

--- a/vinca/templates/build_catkin.sh.in
+++ b/vinca/templates/build_catkin.sh.in
@@ -62,7 +62,8 @@ fi
 
 export SKIP_TESTING=@(skip_testing)
 
-cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX \
+cmake ${CMAKE_ARGS} --compile-no-warning-as-error \
+         -DCMAKE_INSTALL_PREFIX=$PREFIX \
          -DCMAKE_PREFIX_PATH=$PREFIX \
          -DCMAKE_BUILD_TYPE=Release \
          -DCMAKE_INSTALL_LIBDIR=lib \


### PR DESCRIPTION
This, together with downstream packages having changes like https://github.com/PickNikRobotics/RSL/pull/117, should remove the need for all the patches manually removing the `-Werror` compile option.