### PR TITLE
skip_existing: use packages.conda for packages to skip.

### DIFF
--- a/vinca/main.py
+++ b/vinca/main.py
@@ -950,7 +950,7 @@ def main():
                 if "://" in fn:
                     selected_bn = vinca_conf.get("build_number", 0)
                     distro = vinca_conf["ros_distro"]
-                    for pkg_name, pkg in repodata.get("packages").items():
+                    for pkg_name, pkg in repodata.get("packages.conda").items():
                         if pkg_name.startswith(f"ros-{distro}"):
                             if pkg_name.rsplit("-", 2)[0] in additional_recipe_names:
                                 print(

--- a/vinca/main.py
+++ b/vinca/main.py
@@ -240,6 +240,7 @@ def generate_output(pkg_shortname, vinca_conf, distro, version, all_pkgs=None):
                 "${{ compiler('c') }}",
                 "${{ stdlib('c') }}",
                 "ninja",
+                "python",
                 "setuptools",
                 {"if": "unix", "then": ["make", "coreutils"]},
                 {"if": "osx", "then": ["tapi"]},
@@ -255,6 +256,7 @@ def generate_output(pkg_shortname, vinca_conf, distro, version, all_pkgs=None):
             ],
             "host": [
                 {"if": "build_platform == target_platform", "then": ["pkg-config"]},
+                "python",
                 "numpy",
                 "pip",
             ],
@@ -717,6 +719,7 @@ def parse_package(pkg, distro, vinca_conf, path):
                 "${{ compiler('c') }}",
                 "${{ stdlib('c') }}",
                 "ninja",
+                "python",
                 {"if": "unix", "then": ["make", "coreutils"]},
                 "cmake",
                 {"if": "build_platform != target_platform", "then": ["python"]},

--- a/vinca/templates/build_ament_cmake.sh.in
+++ b/vinca/templates/build_ament_cmake.sh.in
@@ -68,6 +68,7 @@ cmake \
     -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True \
     -DBUILD_SHARED_LIBS=ON  \
     -DBUILD_TESTING=OFF \
+    -DCMAKE_IGNORE_PREFIX_PATH="/opt/homebrew;/usr/local/homebrew" \
     -DCMAKE_OSX_DEPLOYMENT_TARGET=$OSX_DEPLOYMENT_TARGET \
     --compile-no-warning-as-error \
     $SRC_DIR/$PKG_NAME/src/work


### PR DESCRIPTION
In the `repodata.json`, `"packages"` is unpopulated, but `"packages.conda"` contains the map of packages.  This PR uses the `"packages.conda"` to determine which packages have already been built.