### PR TITLE
Linux: use ubuntu as Docker image.

### DIFF
--- a/vinca/generate_azure.py
+++ b/vinca/generate_azure.py
@@ -222,7 +222,7 @@ def build_linux_pipeline(
         azure_template = {"pool": {"vmImage": "ubuntu-latest"}}
 
     if docker_image is None:
-        docker_image = "condaforge/linux-anvil-cos7-x86_64"
+        docker_image = "ubuntu"
     azure_stages = []
 
     stage_names = []

--- a/vinca/generate_gha.py
+++ b/vinca/generate_gha.py
@@ -261,7 +261,7 @@ def build_linux_pipeline(
         azure_template = blurb
 
     if docker_image is None:
-        docker_image = "condaforge/linux-anvil-cos7-x86_64"
+        docker_image = "ubuntu"
 
     prev_batch_keys = []
 

--- a/vinca/generate_gitlab.py
+++ b/vinca/generate_gitlab.py
@@ -75,7 +75,7 @@ def main():
 
     print(stages)
 
-    gitlab_template = {"image": "condaforge/linux-anvil-cos7-x86_64"}
+    gitlab_template = {"image": "ubuntu"}
 
     stage_names = []
     for i, s in enumerate(stages):


### PR DESCRIPTION
Current builds fail due to a too low version of `glibc`.  The CentOS 7-based images that are provided by the conda-forge team provide `glibc == 2.17`, but some packages require `glibc >= 2.28`.

```
+ pixi run -e default rattler-build build -v --recipe /home/conda/feedstock_root/recipes/ros2-distro-mutex -m /home/conda/feedstock_root/conda_build_config.yaml -c robostack-jazzy -c conda-forge --output-dir /opt/conda/build_artifacts
  × The current system has a mismatching virtual package. The project requires
  │ '__glibc' to be at least version '2.28' but the system has version '2.17'
```

This PR uses the `ubuntu` latest image to get around this limitation.