### PR TITLE
Allow to specify a different build number for a single package and remove full_rebuild and skip_all_deps options

### DIFF
--- a/vinca/main.py
+++ b/vinca/main.py
@@ -952,7 +952,7 @@ def main():
                 # only URLs
                 if "://" in fn:
                     selected_bn = vinca_conf.get("build_number", 0)
-                    if not vinca_conf.get("use_explicit_build_number", False):
+                    if not vinca_conf.get("use_explicit_build_number", True):
                         distro = vinca_conf["ros_distro"]
                         all_pkgs = repodata.get("packages", {})
                         all_pkgs.update(repodata.get("packages.conda", {}))

--- a/vinca/main.py
+++ b/vinca/main.py
@@ -676,17 +676,16 @@ def get_selected_packages(distro, vinca_conf):
         for i in vinca_conf["packages_select_by_deps"]:
             i = i.replace("-", "_")
             selected_packages = selected_packages.union([i])
-            if "skip_all_deps" not in vinca_conf or not vinca_conf["skip_all_deps"]:
-                if i in skipped_packages:
-                    continue
-                try:
-                    pkgs = distro.get_depends(i, ignore_pkgs=skipped_packages)
-                except KeyError:
-                    # handle (rare) package names that use "-" as separator
-                    pkgs = distro.get_depends(i.replace("_", "-"))
-                    selected_packages.remove(i)
-                    selected_packages.add(i.replace("_", "-"))
-                selected_packages = selected_packages.union(pkgs)
+            if i in skipped_packages:
+                continue
+            try:
+                pkgs = distro.get_depends(i, ignore_pkgs=skipped_packages)
+            except KeyError:
+                # handle (rare) package names that use "-" as separator
+                pkgs = distro.get_depends(i.replace("_", "-"))
+                selected_packages.remove(i)
+                selected_packages.add(i.replace("_", "-"))
+            selected_packages = selected_packages.union(pkgs)
 
     result = sorted(list(selected_packages))
     return result
@@ -976,16 +975,8 @@ def main():
                     is_built = False
                     if selected_bn is not None:
                         pkg_build_number = get_pkg_build_number(selected_bn, pkg["name"], vinca_conf)
-                        if vinca_conf.get("full_rebuild", True):
-                            if pkg["build_number"] == pkg_build_number:
-                                is_built = True
-                        else:
-                            # remove all packages except explicitly selected ones
-                            if (
-                                pkg["name"] not in explicitly_selected_pkgs
-                                or pkg["build_number"] == pkg_build_number
-                            ):
-                                is_built = True
+                        if pkg["build_number"] == pkg_build_number:
+                            is_built = True
                     else:
                         is_built = True
 

--- a/vinca/migrate.py
+++ b/vinca/migrate.py
@@ -113,7 +113,6 @@ def create_migration_instructions(arch, packages_to_migrate, trigger_branch):
     print("Final names: ", ros_names)
 
     vinca_conf["packages_select_by_deps"] = ros_names
-    vinca_conf["skip_all_deps"] = True
     vinca_conf["is_migration"] = True
     vinca_conf["skip_existing"] = []
 

--- a/vinca/template.py
+++ b/vinca/template.py
@@ -7,6 +7,8 @@ import stat
 from ruamel import yaml
 from pathlib import Path
 
+from vinca.utils import get_pkg_build_number
+
 TEMPLATE = """\
 # yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
 
@@ -71,7 +73,6 @@ def copyfile_with_exec_permissions(source_file, destination_file):
         os.chmod(destination_file, current_permissions | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 def write_recipe(source, outputs, vinca_conf, single_file=True):
-    build_number = vinca_conf.get("build_number", 0)
     # single_file = False
     if single_file:
         file = yaml.YAML()
@@ -84,7 +85,7 @@ def write_recipe(source, outputs, vinca_conf, single_file=True):
         meta["package"]["version"] = f"{datetime.datetime.now():%Y.%m.%d}"
         meta["recipe"] = meta["package"]
         del meta["package"]
-        meta["build"]["number"] = build_number
+        meta["build"]["number"] = vinca_conf.get("build_number", 0)
         meta["build"]["post_process"] = post_process_items
         with open("recipe.yaml", "w") as stream:
             file.dump(meta, stream)
@@ -102,7 +103,7 @@ def write_recipe(source, outputs, vinca_conf, single_file=True):
             meta["package"]["name"] = o["package"]["name"]
             meta["package"]["version"] = o["package"]["version"]
 
-            meta["build"]["number"] = build_number
+            meta["build"]["number"] = get_pkg_build_number(vinca_conf.get("build_number", 0), o["package"]["name"], vinca_conf)
             meta["build"]["post_process"] = post_process_items
 
             if test := vinca_conf["_tests"].get(o["package"]["name"]):

--- a/vinca/utils.py
+++ b/vinca/utils.py
@@ -65,3 +65,20 @@ def get_repodata(url_or_path, platform=None):
     with open(fn, "w") as fcache:
         fcache.write(content.decode("utf-8"))
     return json.loads(content)
+
+def ensure_name_is_without_distro_prefix_and_with_underscores(name, vinca_conf):
+    """
+    Ensure that the name is without distro prefix and with underscores
+    e.g. "ros-humble-pkg-name" -> "pkg_name"
+    """
+    newname = name.replace("-", "_")
+    distro_prefix = "ros_" + vinca_conf.get("ros_distro") + "_"
+    if (newname.startswith(distro_prefix) ):
+        newname = newname.replace(distro_prefix, "")
+
+    return newname
+
+def get_pkg_build_number(default_build_number, pkg_name, vinca_conf):
+    normalized_name = ensure_name_is_without_distro_prefix_and_with_underscores(pkg_name, vinca_conf)
+    pkg_additional_info = vinca_conf["_pkg_additional_info"].get(normalized_name, {})
+    return pkg_additional_info.get("build_number", default_build_number)


### PR DESCRIPTION
This commit allow to specify a different build number for a single package, to allow to perform a fix to a build of a single package, without the need to do a full rebuild.

This is an advanced option, so special care is needed:
* A rebuild is only possible if it does not change the version or in any other way the ABI of the package.
* On the following full rebuild, it is important to make sure that the build number select is higher then any custom build number used for single packages.

To permit to do this, I did the following changes:
* I added an optional `pkg_additional_info.yaml` file meant to specify additional package-specific options. I introduced this file here, but it will also be useful for the work I plan to do to easily de-vendor packages (together with https://github.com/ament/ament_cmake/pull/552)
* There was a whole strange logic related to the `selected_bn` variable that I did not fully get, that was using a different build number depending on the build number of the packages present in the target upload channel. I was a bit afraid to simply remove it, but I added the `use_explicit_build_number: True` option to bypass this logic, the idea is that we add `use_explicit_build_number: True` to all the vinca config files, and then if everything works fine, we can simply drop that logic. 


The motivation for this came out as in https://github.com/RoboStack/ros-humble/pull/242 we accidentally did a build of `lanelet2-io` with a wrong pugixml pinning, and in general it would be great to be able to do fixes that preserve the ABI without doing a full rebuild. 