### PR TITLE
fix: remove the hardcoded rmw implementation on darwin

### DIFF
--- a/vinca/templates/activate.sh.in
+++ b/vinca/templates/activate.sh.in
@@ -15,7 +15,7 @@ else
 fi
 
 case "$OSTYPE" in
-  darwin*)  export ROS_OS_OVERRIDE="conda:osx"; export RMW_IMPLEMENTATION="rmw_cyclonedds_cpp";;
+  darwin*)  export ROS_OS_OVERRIDE="conda:osx";;
   linux*)   export ROS_OS_OVERRIDE="conda:linux";;
 esac
 


### PR DESCRIPTION
From a conversation with @traversaro I understand that this isn't required anymore. Feel free to close if that was a miss interpretation and I will make an issue for it. 

The issue was found because setting the `RMW_IMPLEMENTATION` env var before the activation doesn't work on Mac. As it will be overwritten by this line. See the spark for debugging session here: https://github.com/prefix-dev/pixi/issues/2910

