### PR TITLE
Switch linux-aarch64 builds to ubuntu-24.04-arm

### DIFF
--- a/vinca/generate_gha.py
+++ b/vinca/generate_gha.py
@@ -580,7 +580,7 @@ def main():
         build_linux_pipeline(
             stages,
             args.trigger_branch,
-            runs_on="cirun-linux-aarch64--${{ github.run_id }}",
+            runs_on="ubuntu-24.04-arm",
             docker_image="condaforge/linux-anvil-aarch64",
             outfile="linux_aarch64.yml",
         )


### PR DESCRIPTION
After https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/ we can use GitHub Actions also for native builds on `linux-aarch64`.