### PR TITLE
Cleanup README to be minimal but at least up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,19 @@
 # vinca
- Conda recipe generator for ROS packages
+
+rattler-build recipe (i.e. conda recipe v1) generator for ROS packages
 
 **WARNING**:
-This project is at a super early stage.
-No guarantees everything works.
+This project is actively mantained and can frequently change based on the needs of the RoboStack project.
 
 ## Concept
 
-The tool generates `conda` recipe to capture all the selected ROS packages.
-Later, one can use `conda-smithy` to auto-generate pipeline to release `conda` binary packages.
+The tool generates `conda` rattler-build recipes to capture all the selected ROS packages.
 
 ## Example
 
-First you have to create a `vinca.yaml` to describe ROS information for `vinca` to do the magic generating the recipe.
+The repo contains a `vinca` tool that reads a `vinca.yaml` file that contains all its metadata.
 
-```yaml
-# vinca.yaml
-ros_distro: eloquent
-
-# optionally, a fat archive can be generated too.
-fat_archive: true
-name: ros-eloquent-fat-ament-cmake
-
-# mapping of rosdep keys
-# it can be also used to shadow the unwanted packages.
-conda_index:
-  - 'https://github.com/RoboStack/ros-galactic/blob/master/vinca_linux_64.yaml'
-
-# packages to skip
-packages_skip_by_deps:
-
-# packages to include
-packages_select_by_deps:
-  - ament_cmake
-
-# patch directory
-patch_dir: ./patch
-```
-
-### Special modes
-
-#### Build all
-
-To generate recipes for all available ROS packages you can add `build_all: true` to your vinca.yaml. In that case, otherwise selected packages will be ignored and vinca will generate recipes for all available packages. To try to see how far one can go, it's recommended to run vinca and boa like this:
-
-```
-vinca --multiple  # to generate a `./recipes` folder with multiple subfolders
-boa build --skip-existing=fast --continue-on-failure -m conda_build_config.yaml ./recipes
-```
+For an up-to-date example of how to write a `vinca.yaml`, check the repos of the mantained RoboStack distros:
+* https://github.com/RoboStack/ros-noetic/
+* https://github.com/RoboStack/ros-humble
+* https://github.com/RoboStack/ros-jazzy/


### PR DESCRIPTION
I tried to come up with a minimal `vinca.yaml`, but that was difficult. It is more realistic to just point to existing working files in `ros-noetic`, `ros-humble` and `ros-jazzy` repos.