### PR TITLE
fix error when building linux_aarch64 does not require docker anymore

### DIFF
--- a/vinca/generate_gha.py
+++ b/vinca/generate_gha.py
@@ -562,12 +562,12 @@ def main():
 
     if args.platform == "linux-aarch64":
         # Build aarch64 pipeline
-        build_linux_pipeline(
+        build_unix_pipeline(
             stages,
             args.trigger_branch,
             runs_on="ubuntu-24.04-arm",
-            docker_image="condaforge/linux-anvil-aarch64",
             outfile="linux_aarch64.yml",
+            target=platform
         )
 
     # windows


### PR DESCRIPTION
Related to https://github.com/RoboStack/ros-noetic/pull/523

Tested locally and also remotely https://github.com/nmarticorena/ros-humble/actions/runs/14030125332 .

Note that it is failing because the skips on the additional recipes of emscripten are not working. But this should solve the issue introduced to ros-noetic