### PR TITLE
Fix errors when creating build gha

### DIFF
--- a/vinca/generate_gha.py
+++ b/vinca/generate_gha.py
@@ -248,7 +248,7 @@ def build_unix_pipeline(
     azure_template=None,
     runs_on="ubuntu-latest",
     outfile="linux.yml",
-    pipeline_name="build_linux",
+    pipeline_name="build_unix",
     target="",
 ):
     blurb = {"jobs": {}, "name": pipeline_name}
@@ -326,7 +326,8 @@ def build_osx_pipeline(
     outfile="osx.yml",
     azure_template=None,
     script=azure_unix_script,
-    target="osx-64"
+    target="osx-64",
+    pipeline_name="build_osx_64"
 ):
     build_unix_pipeline(
         stages,
@@ -336,6 +337,7 @@ def build_osx_pipeline(
         runs_on=vm_imagename,
         outfile=outfile,
         target=target,
+        pipeline_name=pipeline_name
     )
 
 
@@ -560,6 +562,7 @@ def main():
             outfile="osx_arm64.yml",
             script=azure_unix_script,
             target=platform,
+            pipeline_name="build_osx_arm64"
         )
 
     if args.platform == "linux-aarch64":
@@ -569,7 +572,8 @@ def main():
             args.trigger_branch,
             runs_on="ubuntu-24.04-arm",
             outfile="linux_aarch64.yml",
-            target=platform
+            target=platform,
+            pipeline_name="build_linux_aarch64"
         )
 
     # windows
@@ -581,6 +585,6 @@ def main():
             stages,
             args.trigger_branch,
             outfile="emscripten_wasm32.yml",
-            pipeline_name="emscripten_wasm32",
+            pipeline_name="build_emscripten_wasm32",
             target="emscripten-wasm32",
         )

--- a/vinca/generate_gha.py
+++ b/vinca/generate_gha.py
@@ -326,6 +326,7 @@ def build_osx_pipeline(
     outfile="osx.yml",
     azure_template=None,
     script=azure_unix_script,
+    target="osx-64"
 ):
     build_unix_pipeline(
         stages,
@@ -334,7 +335,7 @@ def build_osx_pipeline(
         azure_template=azure_template,
         runs_on=vm_imagename,
         outfile=outfile,
-        target="osx-64",
+        target=target,
     )
 
 
@@ -558,6 +559,7 @@ def main():
             vm_imagename="macos-14",
             outfile="osx_arm64.yml",
             script=azure_unix_script,
+            target=platform,
         )
 
     if args.platform == "linux-aarch64":


### PR DESCRIPTION
Add fixes when osx-arm64 was called using platform osx-64.

In addition, we change all the pipeline's names to be target-specific.
This should fix the issues on https://github.com/RoboStack/ros-humble/issues/284