### PR TITLE
Add ratter-build style selector for vinca.yaml, dependencies.yaml and pkg_additional_info.yaml

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
   requests >=2.24.0
   networkx >=2.5
   rich >=10
+  jinja2 >=3.0.0
 packages = find:
 zip_safe = false
 

--- a/vinca/main.py
+++ b/vinca/main.py
@@ -14,6 +14,7 @@ from .resolve import get_conda_index
 from .resolve import resolve_pkgname
 from .template import write_recipe, write_recipe_package
 from .distro import Distro
+from .v1_selectors import evaluate_selectors
 
 from vinca import config
 from vinca.utils import get_repodata, get_pkg_build_number
@@ -159,7 +160,7 @@ def get_depmods(vinca_conf, pkg_name):
 
 def read_vinca_yaml(filepath):
     yaml = ruamel.yaml.YAML()
-    vinca_conf = yaml.load(open(filepath, "r"))
+    vinca_conf = evaluate_selectors(yaml.load(open(filepath, "r")), target_platform=get_conda_subdir())
 
     # normalize paths to absolute paths
     conda_index = []
@@ -198,7 +199,7 @@ def read_vinca_yaml(filepath):
     vinca_conf["_tests"] = tests
 
     if (patch_dir / "dependencies.yaml").exists():
-        vinca_conf["depmods"] = yaml.load(open(patch_dir / "dependencies.yaml"))
+        vinca_conf["depmods"] = evaluate_selectors(yaml.load(open(patch_dir / "dependencies.yaml")), target_platform=get_conda_subdir())
     if not vinca_conf.get("depmods"):
         vinca_conf["depmods"] = {}
 
@@ -212,7 +213,7 @@ def read_vinca_yaml(filepath):
     vinca_conf["trigger_new_versions"] = vinca_conf.get("trigger_new_versions", False)
 
     if (Path(filepath).parent / "pkg_additional_info.yaml").exists():
-        vinca_conf["_pkg_additional_info"] = yaml.load(open(Path(filepath).parent / "pkg_additional_info.yaml"))
+        vinca_conf["_pkg_additional_info"] = evaluate_selectors(yaml.load(open(Path(filepath).parent / "pkg_additional_info.yaml")), target_platform=get_conda_subdir())
     else:
         vinca_conf["_pkg_additional_info"] = {}
 

--- a/vinca/test_v1_selectors.py
+++ b/vinca/test_v1_selectors.py
@@ -1,0 +1,64 @@
+import pytest
+import ruamel.yaml
+
+from vinca import v1_selectors
+
+yaml = ruamel.yaml.YAML()
+
+# -----------------------------------------------------------------------------#
+# Fixtures                                                                      #
+# -----------------------------------------------------------------------------#
+@pytest.mark.parametrize(
+    "platform,expected",
+    [
+        (
+            "linux-64",
+            {"requirements": {"host": ["unix-tool"]}},
+        ),
+        (
+            "win-64",
+            {"requirements": {"host": ["win-tool"]}},
+        ),
+    ],
+)
+def test_basic_os_selector(platform, expected):
+    src = """
+    requirements:
+      host:
+        - if: unix
+          then: unix-tool
+        - if: win
+          then: win-tool
+    """
+    data = yaml.load(src)
+    assert v1_selectors.evaluate_selectors(data, target_platform=platform) == expected
+
+
+def test_then_else_branch():
+    src = """
+    - if: linux
+      then:
+        k: 1
+      else:
+        k: 2
+    """
+    data = yaml.load(src)
+    assert v1_selectors.evaluate_selectors(data, target_platform="linux-64") == [{"k": 1}]
+    assert v1_selectors.evaluate_selectors(data, target_platform="win-64") == [{"k": 2}]
+
+
+def test_spliced_list():
+    src = """
+    host:
+      - if: linux
+        then:
+          - linux-tool-1
+          - linux-tool-2
+      - always-tool
+    """
+    data = yaml.load(src)
+    out = v1_selectors.evaluate_selectors(data, target_platform="linux-64")
+    assert out["host"] == ["linux-tool-1", "linux-tool-2", "always-tool"]
+    out2 = v1_selectors.evaluate_selectors(data, target_platform="win-64")
+    assert out2["host"] == ["always-tool"]
+

--- a/vinca/v1_selectors.py
+++ b/vinca/v1_selectors.py
@@ -1,0 +1,164 @@
+"""
+Evaluate rattler-build v1-style selectors (``if`` / ``then`` / optional ``else``)
+inside YAML files already loaded with ``ruamel.yaml``, following the style documented
+in the rattler-build documentation at https://rattler.build/latest/selectors/ .
+One major difference is that build_platform variable is not supported.
+
+Usage
+-----
+>>> from v1_selectors import evaluate_selectors
+>>> data = yaml.load(open("recipe.yaml"))
+>>> clean = evaluate_selectors(data, target_platform="linux-64")
+"""
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping, MutableMapping, Sequence
+
+import jinja2
+
+
+# -----------------------------------------------------------------------------#
+# Helper – platform → selector variables                                       #
+# -----------------------------------------------------------------------------#
+def _platform_flags(platform: str | None) -> dict[str, bool | str]:
+    """Return the boolean/os/arch flags defined by rattler-build."""
+    if not platform:
+        platform = ""
+    os_part, *_rest = platform.split("-", maxsplit=1)
+    arch = _rest[0] if _rest else ""
+
+    # All platforms considered in this logic:
+    # see https://github.com/conda/conda-build/blob/d27c97c11e2316905cefe24deebd3e445e853ece/tests/test_metadata.py#L588
+    # linux-32: Linux x86 (i686, 32-bit)
+    # linux-64:	Linux x86_64 (AMD/Intel 64-bit)
+    # linux-aarch64:	Linux ARM v8 64-bit
+    # linux-armv6l:	Linux ARM v6 32-bit
+    # linux-armv7l:	Linux ARM v7 32-bit
+    # linux-ppc64:	Linux PowerPC 64-bit, big-endian
+    # linux-ppc64le:	Linux PowerPC 64-bit, little-endian
+    # linux-riscv64:	Linux RISC-V 64-bit
+    # linux-s390x:	Linux IBM Z / s390x 64-bit
+    # osx-64:	macOS Intel 64-bit
+    # osx-arm64:	macOS Apple-Silicon ARM64
+    # win-32:	Windows x86 32-bit
+    # win-64:	Windows x86_64 64-bit
+    # win-arm64:	Windows on ARM 64-bit
+    # freebsd-64:	FreeBSD x86_64 64-bit
+    # emscripten-wasm32:	WebAssembly (Emscripten tool-chain)
+    # wasi-wasm32:	WebAssembly for the WASI runtime
+    # zos-z:	IBM z/OS
+
+    flags: dict[str, bool | str] = {
+        "target_platform": platform,
+        # OS
+        "linux": os_part == "linux",
+        "osx": os_part == "osx",
+        "win": os_part == "win",
+        "unix": os_part in {"linux", "osx", "emscripten", "wasi", "freebsd", "zos"},
+        # x86
+        "x86": arch in {"32", "64"},
+        "x86_64": arch in {"64"},
+        # Arm
+        "aarch64": arch in {"aarch64", "arm64"},
+        "arm64": arch in {"aarch64", "arm64"},
+        "armV6l": arch == "armv6l",
+        "armV7l": arch == "armv7l",
+        # Power / s390x
+        "ppc64": arch == "ppc64",
+        "ppc64le": arch == "ppc64le",
+        "s390x": arch == "s390x",
+        # RISC-V / WASM
+        "riscv32": arch == "riscv32",
+        "riscv64": arch == "riscv64",
+        "wasm32": arch == "wasm32",
+    }
+    return flags
+
+
+# -----------------------------------------------------------------------------#
+# Core                                                                         #
+# -----------------------------------------------------------------------------#
+_ENV = jinja2.Environment()
+
+def _eval_condition(expr: str, ctx: Mapping[str, Any]) -> bool:
+    """Safe-ish evaluation of the selector expression using jinja2."""
+    try:
+        fn = _ENV.compile_expression(expr)
+        return bool(fn(ctx))
+    except Exception:
+        # An invalid expression is treated as “False”
+        return False
+
+
+def _process_node(node: Any, ctx: Mapping[str, Any]) -> Any | None:
+    """
+    Recursively walk *node*,
+    resolving any dict that has at least an ``"if"`` and ``"then"`` key.
+
+    Returns
+    -------
+    * New object with selectors resolved
+    * ``None`` --> caller will drop this element (condition false & no else)
+    """
+    # Selector handling --------------------------------------------------------
+    if isinstance(node, Mapping) and "if" in node and "then" in node:
+        cond = str(node["if"])
+        branch = "then" if _eval_condition(cond, ctx) else "else"
+        if branch in node:                          # recurse into chosen branch
+            return _process_node(node[branch], ctx)
+        return None                                 # nothing chosen – drop
+
+    # Recursion – dict ---------------------------------------------------------
+    if isinstance(node, MutableMapping):
+        out: dict[str, Any] = {}
+        for k, v in node.items():
+            new = _process_node(v, ctx)
+            if new is not None:
+                out[k] = new
+        return out
+
+    # Recursion – list ---------------------------------------------------------
+    if isinstance(node, Sequence) and not isinstance(node, (str, bytes)):
+        out: list[Any] = []
+        for item in node:
+            new = _process_node(item, ctx)
+            if new is None:
+                continue
+            # Flatten lists returned from selectors so the example in docs works
+            if isinstance(new, list):
+                out.extend(new)
+            else:
+                out.append(new)
+        return out
+
+    # Scalar – nothing to do ---------------------------------------------------
+    return node
+
+
+# Public entry point -----------------------------------------------------------
+def evaluate_selectors(
+    data: Any,
+    *,
+    target_platform: str,
+) -> Any:
+    """
+    Return *data* with all rattler-build selectors evaluated.
+
+    Parameters
+    ----------
+    data : Any
+        Parsed YAML object (``ruamel`` or ``PyYAML``).
+    target_platform : str
+        ``linux-64``, ``osx-arm64``, etc.).
+
+    Notes
+    -----
+    * Unknown variables inside the condition evaluate to *False*.
+    * The “then” branch can be a scalar, mapping or list.
+      If it is a list, items are *spliced* into the parent list so that
+      multi-item examples from the rattler-build docs work naturally.
+    """
+    ctx = _platform_flags(target_platform)
+
+    return _process_node(copy.deepcopy(data), ctx)


### PR DESCRIPTION
This PR adds the feature of rattler-build/conda recipe v1 style yaml selectors, as documented in https://rattler.build/latest/selectors/ . This permits to remove the duplication among vinca files in the ros-* repos, and permits to keep a single vinca.yaml files where difference across platforms are handled by selectors.

For an example of a working vinca.yaml, this is an example of a rolling build I am playing with:

~~~yaml
ros_distro: rolling

# mapping for package keys
conda_index:
  - robostack.yaml
  - packages-ignore.yaml

# Reminder for next full rebuild, the next build number should be 8
build_number: 1

mutex_package: ros2-distro-mutex 0.1.* rolling_*

skip_all_deps: false

# If full rebuild, the build number of the existing package has
# to match the selected build number for skipping
full_rebuild: true

packages_skip_by_deps:
  - cartographer
  - urdfdom
  - urdfdom_headers
  - urdfdom_py
  - octomap
  - if: not linux
    then:
      - rttest
      - tlsf
      - tlsf_cpp
      - pendulum_control

packages_remove_from_deps:
  - cartographer
  - if: not linux
    then:
      - rttest
      - tlsf
      - tlsf_cpp
      - pendulum_control


skip_existing:
  # - output
  - https://conda.anaconda.org/robostack-rolling/

packages_select_by_deps:
  - ament_cmake_core
  - ament_cmake_catch2
  - ament_cmake_mypy

  - desktop
  - ros_base
  - ros_environment
  - ros_workspace
  - dev_tools
  - diagnostics
  - teleop
  - robot
  - perception
  - navigation2
  - simulation
  - desktop_full

  - moveit
  - moveit-planners-chomp
  - moveit-servo
  - moveit-visual-tools

  - ros2_control
  - ros2_controllers
  - gz_ros2_control
  - gz_ros2_control_demos

  - rviz_visual_tools

  - ur
  - ur_simulation_gz

  - ros_gz
  - slam_toolbox
  - turtlebot3



  - if: not win
    then:
      # skip for now
      - plotjuggler-ros
      # velodyne packages are not supported on Windows
      - velodyne
      # Commented out as in the next rebuild on Windows we will switch to use the conda-forge version
      - gtsam
      - foxglove_compressed_video_transport
      - gridmap
      # TODO: fix iconv link issue on Windows
      - ffmpeg_image_transport

  - apriltag_ros

  - ackermann-msgs
  - velodyne
  - sbg_driver
  - gtsam

  # requested in https://github.com/RoboStack/ros-humble/issues/249
  - twist_mux

  # requested in https://github.com/RoboStack/ros-humble/issues/252
  - rmw_zenoh_cpp

  - flex_sync
  - gripper_controllers

  - ament_cmake_mypy
  - rosbridge_suite

  - grid_map

  - foxglove_bridge
  - foxglove_compressed_video_transport
  - foxglove_msgs

  - lanelet2

  - ublox

  - can_msgs
  - ros2_socketcan_msgs

  # socketcan is only available on linux
  - if: linux
    then:
      - ros2_socketcan

  - nav2_bringup

  - autoware_internal_msgs
  - autoware_common_msgs
  - autoware_control_msgs
  - autoware_localization_msgs
  - autoware_map_msgs
  - autoware_perception_msgs
  - autoware_planning_msgs
  - autoware_sensing_msgs
  - autoware_system_msgs
  - autoware_v2x_msgs
  - autoware_vehicle_msgs
  - autoware_cmake
  - autoware_utils



patch_dir: patch
rosdistro_snapshot: rosdistro_snapshot.yaml

~~~
