### PR TITLE
Remove the need for most manually managed additional_recipes

### DIFF
--- a/vinca/distro.py
+++ b/vinca/distro.py
@@ -1,4 +1,5 @@
 import os
+import urllib.request
 
 from rosdistro import get_cached_distribution, get_index, get_index_url
 from rosdistro.dependency_walker import DependencyWalker
@@ -6,11 +7,13 @@ from rosdistro.manifest_provider import get_release_tag
 
 
 class Distro(object):
-    def __init__(self, distro_name, python_version=None, snapshot=None):
+    def __init__(self, distro_name, python_version=None, snapshot=None, additional_packages_snapshot=None):
         index = get_index(get_index_url())
         self._distro = get_cached_distribution(index, distro_name)
         self.distro_name = distro_name
         self.snapshot = snapshot
+        self.additional_packages_snapshot = additional_packages_snapshot
+
         # set up ROS environments
         if python_version is None:
             python_version = index.distributions[distro_name]["python_version"]
@@ -40,10 +43,39 @@ class Distro(object):
 
     def get_depends(self, pkg, ignore_pkgs=None):
         dependencies = set()
-        if pkg not in self._distro.release_packages:
-            print(f"{pkg} not in released packages anymore")
+
+        if not self.check_package(pkg):
+            print(f"{pkg} not in available packages anymore")
             return dependencies
 
+        # if pkg comes from additional_packages_snapshot, extract from its package.xml
+        if self.additional_packages_snapshot and pkg in self.additional_packages_snapshot:
+            pkg_info = self.additional_packages_snapshot[pkg]
+            xml_str = self.get_package_xml_for_additional_package(pkg_info)
+            # parse XML
+            import xml.etree.ElementTree as ET
+            root = ET.fromstring(xml_str)
+            # collect direct dependencies tags from package.xml
+            dep_tags = [
+                'depend', 'build_depend', 'buildtool_depend', 'buildtool_export_depend',
+                'exec_depend', 'run_depend', 'test_depend', 'build_export_depend'
+            ]
+            direct = set()
+            for tag in dep_tags:
+                for elem in root.findall(f'.//{tag}'):
+                    if elem.text:
+                        name = elem.text.strip()
+                        direct.add(name)
+            # add direct deps
+            dependencies |= direct
+            # recursively collect dependencies
+            for dep in direct:
+                if ignore_pkgs and dep in ignore_pkgs:
+                    continue
+                dependencies |= self.get_depends(dep, ignore_pkgs=ignore_pkgs)
+            return dependencies
+
+        # If the package is from upstream rosdistro, use the walker to get dependencies
         dependencies |= self._walker.get_recursive_depends(
             pkg,
             [
@@ -73,6 +105,11 @@ class Distro(object):
         return repo.url, release_tag
 
     def check_package(self, pkg_name):
+        # If the package is in the additional_packages_snapshot, it is always considered valid
+        # even if it is not in the released packages, as it is an additional
+        # package specified in rosdistro_additional_recipes.yaml
+        if self.additional_packages_snapshot and pkg_name in self.additional_packages_snapshot:
+            return True
         if pkg_name in self._distro.release_packages:
             return self.snapshot is None or pkg_name in self.snapshot
         elif pkg_name in self.build_packages:
@@ -89,6 +126,9 @@ class Distro(object):
         return repo.version.split("-")[0]
 
     def get_release_package_xml(self, pkg_name):
+        if self.additional_packages_snapshot and pkg_name in self.additional_packages_snapshot:
+            pkg_info = self.additional_packages_snapshot[pkg_name]
+            return self.get_package_xml_for_additional_package(pkg_info)
         return self._distro.get_release_package_xml(pkg_name)
 
     def check_ros1(self):
@@ -99,3 +139,23 @@ class Distro(object):
 
     def get_package_names(self):
         return self._distro.release_packages.keys()
+
+    # Based on https://github.com/ros-infrastructure/rosdistro/blob/fad8d9f647631945847cb18bc1d1f43008d7a282/src/rosdistro/manifest_provider/github.py#L51C1-L69C29
+    # But with the option to specify the name of the package.xml file in case the repo uses a non-standard name
+    def get_package_xml_for_additional_package(self, pkg_info):
+        # Build raw GitHub URL for package.xml
+        raw_url_base = pkg_info.get("url")
+        if raw_url_base.endswith(".git"):
+            raw_url_base = raw_url_base[:-4]
+        if "github.com" not in raw_url_base:
+            raise RuntimeError(f"Cannot handle non-GitHub URL: {raw_url_base}")
+        # Extract owner/repo
+        owner_repo = raw_url_base.split("github.com/")[-1]
+        tag = pkg_info.get("tag")
+        xml_name = pkg_info.get("package_xml_name", "package.xml")
+        raw_url = f"https://raw.githubusercontent.com/{owner_repo}/{tag}/{xml_name}"
+        try:
+            with urllib.request.urlopen(raw_url) as resp:
+                return resp.read().decode('utf-8')
+        except Exception as e:
+            raise RuntimeError(f"Failed to fetch package.xml from {raw_url}: {e}")

--- a/vinca/template.py
+++ b/vinca/template.py
@@ -96,7 +96,13 @@ def write_recipe(source, outputs, vinca_conf, single_file=True):
             file.indent(mapping=2, sequence=4, offset=2)
             meta = file.load(TEMPLATE)
 
-            meta["source"] = source[o["package"]["name"]]
+            # safe lookup of source entry; dummy recipes may not have a source
+            # only include source section if entry is present, else remove it (dummy recipes)
+            src_entry = source.get(o["package"]["name"], {})
+            if src_entry:
+                meta["source"] = src_entry
+            else:
+                meta.pop("source", None)
             for k, v in o.items():
                 meta[k] = v
 
@@ -117,7 +123,7 @@ def write_recipe(source, outputs, vinca_conf, single_file=True):
             with open(recipe_dir / "recipe.yaml", "w") as stream:
                 file.dump(meta, stream)
 
-            if meta["source"].get("patches"):
+            if meta.get("source") and meta["source"].get("patches"):
                 for p in meta["source"]["patches"]:
                     patch_dir, _ = os.path.split(p)
                     os.makedirs(recipe_dir / patch_dir, exist_ok=True)

--- a/vinca/utils.py
+++ b/vinca/utils.py
@@ -78,7 +78,20 @@ def ensure_name_is_without_distro_prefix_and_with_underscores(name, vinca_conf):
 
     return newname
 
-def get_pkg_build_number(default_build_number, pkg_name, vinca_conf):
+def get_pkg_additional_info(pkg_name, vinca_conf):
     normalized_name = ensure_name_is_without_distro_prefix_and_with_underscores(pkg_name, vinca_conf)
     pkg_additional_info = vinca_conf["_pkg_additional_info"].get(normalized_name, {})
+    return pkg_additional_info
+
+def get_pkg_build_number(default_build_number, pkg_name, vinca_conf):
+    pkg_additional_info = get_pkg_additional_info(pkg_name, vinca_conf)
     return pkg_additional_info.get("build_number", default_build_number)
+
+# Return true if the package is actually provided in conda-forge, and so we generate
+# only a recipe with a run dependency on the conda forge package
+def is_dummy_metapackage(pkg_name, vinca_conf):
+    pkg_additional_info = get_pkg_additional_info(pkg_name, vinca_conf)
+    if pkg_additional_info.get("generate_dummy_package_with_run_deps"):
+        return True
+    else:
+        return False


### PR DESCRIPTION
One of the major annoyances in maintaining the robostack ros distros is the need to manually maintain the `additional_recipes`. These are mainly used for two reasons:
* R1: To create `dummy` packages for ROS packages that are actually already in conda-forge. This includes typically packages like `urdfdom`, `urdfdom_py` and similar.
* R2: Include in robostack distribution packages like `livox_ros_driver2`, that have upstream dependencies that are not available in apt but is available in conda-forge, and so it make sense to package them only in robostack.

This PR remove the need of having additional package of both types R1 and R2, but adding support for generating the recipes for this packages directly as part of the regular recipe generation process, simplifying the tooling related to this recipes.

### Dummy metapackages

In particular, to easily support `R1` recipes, this PR adds support for a new section in `pkg_additional_info.yaml`, that can be used to mark a package as "dummy metapackage", that should not actually compile anything, but just add a dependency on a conda-forge package, in this style:

~~~
octomap:
  generate_dummy_package_with_run_deps:
    dep_name: octomap
    max_pin: 'x.x'
urdfdom_py:
  generate_dummy_package_with_run_deps:
    dep_name: urdfdom-py
    max_pin: 'x.x'
urdfdom_headers:
  generate_dummy_package_with_run_deps:
    dep_name: urdfdom_headers
    max_pin: 'x.x'
urdfdom:
  generate_dummy_package_with_run_deps:
    dep_name: urdfdom
    max_pin: 'x.x'
~~~

The `dep_name` key indicates the name of the dependency in conda-forge, while the `max_pin` indicates the version constraint to use for the dependency on dep_name in the dumy metapackage. For example, if a ROS distro packages urdfdom 4.0.0, then if max_pin is x.x, the generated constraint will be `urdfdom >=4.0.0,<4.1.0a0`. If a conda-forge package has a `run_exports` section, the `max_pin` in this file should match it. I suspect we may also need a `version_override` key to avoid conflicting version constraints between conda-forge pinning and ROS distributions, but for the time being let's start with a simple solution and add complexity if needed.

### Non-packaged in upstream rosdistro packages

To handle cases like `livox_ros_driver2` added in https://github.com/RoboStack/ros-jazzy/pull/53, this PR adds support for an additional `rosdistro_additional_recipes.yaml` file, that follow the structure of the `rosdistro_snapshot.yaml` file, but differently from `rosdistro_snapshot.yaml` it is not automatically generated, but rather manually mantained. This is an example of the content of the `rosdistro_additional_recipes.yaml` file:

~~~
# This file is used to add additional recipes to the ROS 2 distribution, not contained in the
# upstream rosdistro. Differently from rosdistro_snapshot.yaml, this file is not
# automatically generated, but manually maintained.
livox_ros_driver2:
  tag: 1.2.4
  url: https://github.com/Livox-SDK/livox_ros_driver2.git
  version: 1.2.4
  # This is not part of the regular snapshot, but it is an additional argument used to
  # support packages that stores their package.xml under a different name. For any
  # other modification, regular patch files should be used.
  package_xml_name: package_ROS2.xml
~~~

The `tag`, `url` and `version` keys have the same role of the one in  `rosdistro_snapshot.yaml`. In the case of `livox_ros_driver2` the package file to use was not named `package.xml`, so it was also added an additional key named `package_xml_name` to specify the package.xml file to use from the repo. This could not be handled by a patch as this info is needed during the recipe generation phase. For any other modification, regular patches for the package can be added in the `patch` directory, as the package is handled as any other package generated by vinca.
