### PR TITLE
Fix small error when vinca conf file does not have a snapshot

### DIFF
--- a/vinca/main.py
+++ b/vinca/main.py
@@ -222,7 +222,7 @@ def read_vinca_yaml(filepath):
 
 def read_snapshot(vinca_conf):
     if not "rosdistro_snapshot" in vinca_conf:
-        return None
+        return None , None
 
     yaml = ruamel.yaml.YAML()
     # load primary snapshot


### PR DESCRIPTION
This pr solves the issue on https://github.com/RoboStack/ros-humble/issues/311 
