### PR TITLE
Directly generate build script in recipe folder, and support additional_cmake_args  and additional_folder arguments

### DIFF
--- a/vinca/distro.py
+++ b/vinca/distro.py
@@ -153,7 +153,10 @@ class Distro(object):
         owner_repo = raw_url_base.split("github.com/")[-1]
         tag = pkg_info.get("tag")
         xml_name = pkg_info.get("package_xml_name", "package.xml")
-        raw_url = f"https://raw.githubusercontent.com/{owner_repo}/{tag}/{xml_name}"
+        additional_folder = pkg_info.get("additional_folder", "")
+        if additional_folder != "":
+            additional_folder = additional_folder + "/"
+        raw_url = f"https://raw.githubusercontent.com/{owner_repo}/{tag}/{additional_folder}{xml_name}"
         try:
             with urllib.request.urlopen(raw_url) as resp:
                 return resp.read().decode('utf-8')

--- a/vinca/main.py
+++ b/vinca/main.py
@@ -1084,20 +1084,6 @@ def main():
 
     snapshot, additional_packages_snapshot = read_snapshot(vinca_conf)
 
-    from .template import generate_bld_ament_cmake
-    from .template import generate_bld_ament_python
-    from .template import generate_bld_catkin
-    from .template import generate_activate_hook
-    from .template import generate_bld_colcon_merge
-    from .template import generate_bld_catkin_merge
-
-    generate_bld_ament_cmake()
-    generate_bld_ament_python()
-    generate_bld_catkin()
-    generate_bld_colcon_merge()
-    generate_bld_catkin_merge()
-    generate_activate_hook()
-
     if arguments.trigger_new_versions:
         vinca_conf["trigger_new_versions"] = True
     else:

--- a/vinca/main.py
+++ b/vinca/main.py
@@ -1084,6 +1084,9 @@ def main():
 
     snapshot, additional_packages_snapshot = read_snapshot(vinca_conf)
 
+    # Store additional_packages_snapshot in vinca_conf for template access
+    vinca_conf["_additional_packages_snapshot"] = additional_packages_snapshot or {}
+
     if arguments.trigger_new_versions:
         vinca_conf["trigger_new_versions"] = True
     else:

--- a/vinca/templates/bld_ament_cmake.bat.in
+++ b/vinca/templates/bld_ament_cmake.bat.in
@@ -44,7 +44,7 @@ cmake ^
     --compile-no-warning-as-error ^
     -DPYTHON_INSTALL_DIR=%PYTHON_INSTALL_DIR% ^
     @(additional_cmake_args) ^
-    %SRC_DIR%\%PKG_NAME%\src\work
+    %SRC_DIR%\%PKG_NAME%\src\work\@(additional_folder)
 if errorlevel 1 exit 1
 
 :: We explicitly pass %CPU_COUNT% to cmake --build as we are not using Ninja,

--- a/vinca/templates/bld_ament_cmake.bat.in
+++ b/vinca/templates/bld_ament_cmake.bat.in
@@ -43,6 +43,7 @@ cmake ^
     -DCMAKE_OBJECT_PATH_MAX=255 ^
     --compile-no-warning-as-error ^
     -DPYTHON_INSTALL_DIR=%PYTHON_INSTALL_DIR% ^
+    @(additional_cmake_args) ^
     %SRC_DIR%\%PKG_NAME%\src\work
 if errorlevel 1 exit 1
 

--- a/vinca/templates/bld_ament_python.bat.in
+++ b/vinca/templates/bld_ament_python.bat.in
@@ -4,7 +4,7 @@ setlocal
 
 set "PYTHONPATH=%LIBRARY_PREFIX%\lib\site-packages;%SP_DIR%"
 
-pushd %SRC_DIR%\%PKG_NAME%\src\work
+pushd %SRC_DIR%\%PKG_NAME%\src\work\@(additional_folder)
 set "PKG_NAME_SHORT=%PKG_NAME:*ros-@(ros_distro)-=%"
 set "PKG_NAME_SHORT=%PKG_NAME_SHORT:-=_%"
 

--- a/vinca/templates/bld_catkin.bat.in
+++ b/vinca/templates/bld_catkin.bat.in
@@ -42,6 +42,7 @@ cmake ^
     -DBoost_USE_STATIC_LIBS=OFF ^
     %CATKIN_BUILD_BINARY_PACKAGE_ARGS% ^
     -DCATKIN_SKIP_TESTING=%SKIP_TESTING% ^
+    @(additional_cmake_args) ^
     %SRC_DIR%\%PKG_NAME%\src\work
 if errorlevel 1 exit 1
 

--- a/vinca/templates/bld_catkin.bat.in
+++ b/vinca/templates/bld_catkin.bat.in
@@ -43,7 +43,7 @@ cmake ^
     %CATKIN_BUILD_BINARY_PACKAGE_ARGS% ^
     -DCATKIN_SKIP_TESTING=%SKIP_TESTING% ^
     @(additional_cmake_args) ^
-    %SRC_DIR%\%PKG_NAME%\src\work
+    %SRC_DIR%\%PKG_NAME%\src\work\@(additional_folder)
 if errorlevel 1 exit 1
 
 if "%PKG_NAME%" == "ros-@(ros_distro)-eigenpy" (

--- a/vinca/templates/build_ament_cmake.sh.in
+++ b/vinca/templates/build_ament_cmake.sh.in
@@ -128,6 +128,7 @@ $CMAKE_GEN \
     -DCMAKE_OSX_DEPLOYMENT_TARGET=$OSX_DEPLOYMENT_TARGET \
     --compile-no-warning-as-error \
     $EXTRA_CMAKE_ARGS \
+    @(additional_cmake_args) \
     $WORK_DIR
 
 $CMAKE_BLD --build . --config $BUILD_TYPE --target install

--- a/vinca/templates/build_ament_cmake.sh.in
+++ b/vinca/templates/build_ament_cmake.sh.in
@@ -103,7 +103,7 @@ elif [ "${PKG_NAME}" == "ros-humble-wasm-cpp" ]; then
 elif [ "${PKG_NAME}" == "dynmsg" ]; then
   WORK_DIR=$SRC_DIR/$PKG_NAME/src/work/dynmsg
 else
-  WORK_DIR=$SRC_DIR/$PKG_NAME/src/work
+  WORK_DIR=$SRC_DIR/$PKG_NAME/src/work/@(additional_folder)
 fi;
 
 $CMAKE_GEN \

--- a/vinca/templates/build_ament_python.sh.in
+++ b/vinca/templates/build_ament_python.sh.in
@@ -3,7 +3,7 @@
 
 set -eo pipefail
 
-pushd $SRC_DIR/$PKG_NAME/src/work
+pushd $SRC_DIR/$PKG_NAME/src/work/@(additional_folder)
 
 # If there is a setup.cfg that contains install-scripts then we should not set it here
 if [ -f setup.cfg ] && grep -q "install[-_]scripts" setup.cfg; then

--- a/vinca/templates/build_catkin.sh.in
+++ b/vinca/templates/build_catkin.sh.in
@@ -113,7 +113,7 @@ cmake ${CMAKE_ARGS} --compile-no-warning-as-error \
          $EXTRA_CMAKE_ARGS \
          @(additional_cmake_args) \
          -G "$GENERATOR" \
-         $SRC_DIR/$PKG_NAME/src/work
+         $SRC_DIR/$PKG_NAME/src/work/@(additional_folder)
 
 cmake --build . --config Release --target all
 

--- a/vinca/templates/build_catkin.sh.in
+++ b/vinca/templates/build_catkin.sh.in
@@ -111,6 +111,7 @@ cmake ${CMAKE_ARGS} --compile-no-warning-as-error \
          -DCATKIN_BUILD_BINARY_PACKAGE=$CATKIN_BUILD_BINARY_PACKAGE \
          -DCMAKE_OSX_DEPLOYMENT_TARGET=$OSX_DEPLOYMENT_TARGET \
          $EXTRA_CMAKE_ARGS \
+         @(additional_cmake_args) \
          -G "$GENERATOR" \
          $SRC_DIR/$PKG_NAME/src/work
 


### PR DESCRIPTION
This PR fixes https://github.com/RoboStack/vinca/issues/82 and helps https://github.com/RoboStack/ros-humble/issues/309 . 

The changes are:
* https://github.com/RoboStack/vinca/commit/3a5471facf4d674f09db16c7d00dcc64f44ad480 : generate build script directly in recipes, without creating an intermediate value where `vinca` is invoked
* https://github.com/RoboStack/vinca/commit/30f866588ccfb7e0d3766c0d5f1c65dd30464551 : add support to specify additional_cmake_args argument in pkg_additional_info.yaml
* https://github.com/RoboStack/vinca/pull/84/commits/f9d363da657ee747ada3fa9c4eea29c4e1e8fe0e : add support to specify additional_folder argument in rosdistro_additional_recipes.yaml