### PR TITLE
Add support for specify rev in place of tag in rosdistro_additional_recipes.yaml

### DIFF
--- a/vinca/main.py
+++ b/vinca/main.py
@@ -641,10 +641,10 @@ def generate_source(distro, vinca_conf):
         # skip cloning source for dummy recipes
         if is_dummy_metapackage(pkg_shortname, vinca_conf):
             continue
-        url, version = distro.get_released_repo(pkg_shortname)
+        url, ref, ref_type = distro.get_released_repo(pkg_shortname)
         entry = {}
         entry["git"] = url
-        entry["tag"] = version
+        entry[ref_type] = ref
         pkg_names = resolve_pkgname(pkg_shortname, vinca_conf, distro)
         pkg_version = distro.get_version(pkg_shortname)
         print("Checking ", pkg_shortname, pkg_version)
@@ -695,11 +695,11 @@ def generate_source_version(distro, vinca_conf):
             print(f"Could not generate source for {pkg_shortname}")
             continue
 
-        url, version = distro.get_released_repo(pkg_shortname)
+        url, ref, ref_type = distro.get_released_repo(pkg_shortname)
 
         entry = {}
         entry["git"] = url
-        entry["tag"] = version
+        entry[ref_type] = ref
         pkg_names = resolve_pkgname(pkg_shortname, vinca_conf, distro)
         if vinca_conf.get("trigger_new_versions"):
             if (
@@ -736,10 +736,10 @@ def generate_fat_source(distro, vinca_conf):
             print(f"Could not generate source for {pkg_shortname}")
             continue
 
-        url, version = distro.get_released_repo(pkg_shortname)
+        url, ref, ref_type = distro.get_released_repo(pkg_shortname)
         entry = {}
         entry["git"] = url
-        entry["tag"] = version
+        entry[ref_type] = ref
         pkg_names = resolve_pkgname(pkg_shortname, vinca_conf, distro)
         if not pkg_names:
             continue


### PR DESCRIPTION
In https://github.com/RoboStack/ros-humble/pull/320 the additional recipes required by the emscripten build were using commits as reference instead of tag, so for example using:

~~~yaml
rmw_wasm_cpp:
  tag: a8e824af1c9d8683bc5ba5b6cbd210ddd8947dc9
  url: https://github.com/ros2wasm/rmw_wasm.git
  version: 0.0.2
  additional_folder: rmw_wasm_cpp
~~~

resulted in the rattler-build error:

~~~
 ╰─────────────────── (took 0 seconds)
Error:   × Failed to run git command: failed to git fetch refs from origin: fatal:
  │ couldn't find remote ref refs/tags/
  │ a8e824af1c9d8683bc5ba5b6cbd210ddd8947dc9
  │ 
~~~

this PR permits to explicitly use `rev` in place of `tag` in ``, for example:

~~~yaml
rmw_wasm_cpp:
  rev: a8e824af1c9d8683bc5ba5b6cbd210ddd8947dc9
  url: https://github.com/ros2wasm/rmw_wasm.git
  version: 0.0.2
  additional_folder: rmw_wasm_cpp
~~~

to permit to specify checkouts in place of tags.