### PR TITLE
Add support for copying files specified in subfolders of tests folder  to the recipe folder

### DIFF
--- a/vinca/main.py
+++ b/vinca/main.py
@@ -194,6 +194,8 @@ def read_vinca_yaml(filepath):
 
     tests = {}
     test_dir = Path(filepath).parent / "tests"
+    # Store the test directory directly for use in template.py
+    vinca_conf["_test_dir"] = test_dir
     for x in test_dir.glob("*.yaml"):
         tests[os.path.basename(x).split(".")[0]] = x
     vinca_conf["_tests"] = tests

--- a/vinca/template.py
+++ b/vinca/template.py
@@ -120,6 +120,25 @@ def write_recipe(source, outputs, vinca_conf, single_file=True):
 
             recipe_dir = (Path("recipes") / o["package"]["name"]).absolute()
             os.makedirs(recipe_dir, exist_ok=True)
+
+            # Copy test folder contents if corresponding test folder exists
+            test_dir = vinca_conf.get("_test_dir")
+            if test_dir is not None:
+                test_folder_name = o["package"]["name"]
+                test_folder_path = test_dir / test_folder_name
+
+                if test_folder_path.exists() and test_folder_path.is_dir():
+                    # Copy all contents of the test folder to the recipe directory
+                    for item in test_folder_path.iterdir():
+                        if item.is_file():
+                            shutil.copy2(item, recipe_dir / item.name)
+                        elif item.is_dir():
+                            # Use copytree for directories, but handle existing directories
+                            dest_dir = recipe_dir / item.name
+                            if dest_dir.exists():
+                                shutil.rmtree(dest_dir)
+                            shutil.copytree(item, dest_dir)
+
             with open(recipe_dir / "recipe.yaml", "w") as stream:
                 file.dump(meta, stream)
 


### PR DESCRIPTION
Fix https://github.com/RoboStack/vinca/issues/75 . 

After this PR, if a folder named `ros-humble-robot-state-publisher` exists in the `tests` folder, all the contents of the files will be copied in the recipe directory of the recipe of the recipe named `ros-humble-robot-state-publisher`.