### PR TITLE
Fix vinca-snapshot after change of get_released_repo signature

### DIFF
--- a/vinca/snapshot.py
+++ b/vinca/snapshot.py
@@ -66,7 +66,7 @@ def main():
 
     for dep in deps:
         try:
-            url, tag = distro.get_released_repo(dep)
+            url, tag, _ = distro.get_released_repo(dep)
             version = distro.get_version(dep)
         except AttributeError:
             print("\033[93mPackage '{}' has no version set, skipping...\033[0m".format(dep))


### PR DESCRIPTION
I did not realized that the change in https://github.com/RoboStack/vinca/pull/87 was a breaking change, without this fix `vinca-snapshot` fails with:

~~~
traversaro@IITBMP014LW012:~/ros-jazzy$ pixi run vinca-snapshot
Package                                           Version
Traceback (most recent call last):
  File "/home/traversaro/ros-jazzy/.pixi/envs/default/bin/vinca-snapshot", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/traversaro/ros-jazzy/.pixi/envs/default/lib/python3.12/site-packages/vinca/snapshot.py", line 69, in main
    url, tag = distro.get_released_repo(dep)
    ^^^^^^^^
ValueError: too many values to unpack (expected 2)
~~~