### PR TITLE
fix: EDL-1.0 is BSD-3-Clause

### DIFF
--- a/vinca/license_utils.py
+++ b/vinca/license_utils.py
@@ -45,13 +45,14 @@ LICENSE_LOOKUP: Dict[str, str] = {
     "lgplv3": "LGPL-3.0-only",
     "lgpl-3": "LGPL-3.0-only",
     "lgpl-3.0": "LGPL-3.0-only",
+    "LGPL (amcl)": "LGPL-2.1-or-later",
     # Mozilla/MPL variants
     "mozilla": "MPL-2.0",
     "mpl": "MPL-2.0",
     "mozilla public license version 1.1": "MPL-1.1",
     # Eclipse variants
     "eclipse public license 2.0": "EPL-2.0",
-    "eclipse distribution license 1.0": "EDL-1.0",
+    "eclipse distribution license 1.0": "BSD-3-Clause",
     # Boost variants
     "boost": "BSL-1.0",
     "boost software license": "BSL-1.0",
@@ -63,6 +64,7 @@ LICENSE_LOOKUP: Dict[str, str] = {
     # Creative Commons
     "cc by-nc-sa 4.0": "CC-BY-NC-SA-4.0",
     "creative commons zero v1.0 universal": "CC0-1.0",
+    "creative commons": "CC0-1.0",  # The version is an assumption
     # Public Domain (choosing Unlicense as more appropriate for code)
     "public domain": "Unlicense",
 }

--- a/vinca/test_license_utils.py
+++ b/vinca/test_license_utils.py
@@ -93,8 +93,8 @@ def test_all_todos():
 
 def test_license_with_spaces_converted():
     """Test licenses with spaces have spaces replaced with hyphens."""
-    result = convert_to_spdx_license(["Creative Commons"])
-    assert result == "LicenseRef-Creative-Commons"
+    result = convert_to_spdx_license(["My License"])
+    assert result == "LicenseRef-My-License"
 
 
 def test_license_with_slashes_converted():
@@ -250,7 +250,7 @@ def test_additional_license_variants():
 
     # Eclipse variants
     assert convert_to_spdx_license(["Eclipse Public License 2.0"]) == "EPL-2.0"
-    assert convert_to_spdx_license(["Eclipse Distribution License 1.0"]) == "EDL-1.0"
+    assert convert_to_spdx_license(["Eclipse Distribution License 1.0"]) == "BSD-3-Clause"
 
     # Zlib
     assert convert_to_spdx_license(["zlib License"]) == "Zlib"

--- a/vinca/test_license_utils.py
+++ b/vinca/test_license_utils.py
@@ -250,7 +250,9 @@ def test_additional_license_variants():
 
     # Eclipse variants
     assert convert_to_spdx_license(["Eclipse Public License 2.0"]) == "EPL-2.0"
-    assert convert_to_spdx_license(["Eclipse Distribution License 1.0"]) == "BSD-3-Clause"
+    assert (
+        convert_to_spdx_license(["Eclipse Distribution License 1.0"]) == "BSD-3-Clause"
+    )
 
     # Zlib
     assert convert_to_spdx_license(["zlib License"]) == "Zlib"


### PR DESCRIPTION
Fixes #106.

Also fixes some weird license specification used in noetic.

Changed:

* `LGPL (amcl)` -> `LGPL-2.1-or-later`
* [`eclipse distribution license 1.0`](https://www.eclipse.org/org/documents/edl-v10.php) -> `BSD-3-Clause` 
* `creative commons` -> `CC0-1.0`