### PR TITLE
Restore linux.yml for output name of generated GHA workflow

### DIFF
--- a/vinca/generate_gha.py
+++ b/vinca/generate_gha.py
@@ -552,7 +552,7 @@ def main():
         build_unix_pipeline(
             stages,
             args.trigger_branch,
-            outfile="linux64.yml",
+            outfile="linux.yml",
             pipeline_name="build_linux64",
         )
 


### PR DESCRIPTION
Most ros-* repos assume that the file name is called `linux.yml`: 
* https://github.com/RoboStack/ros-jazzy/blob/d483e995264639612b7dc3487ae162c15cc63e86/.github/workflows/main.yml#L32
* https://github.com/RoboStack/ros-kilted/blob/aed53439eeceeaf24acb5d7f9b70046ebf2a96bc/.github/workflows/main.yml#L32

and the silent change of name was a bit tricky to debug (see https://github.com/RoboStack/ros-humble/issues/372).

So I think it is safer to restore the old name before the change https://github.com/RoboStack/vinca/commit/5f9a3ccd1ff091386ec307c75181b8d1c282b18d. If then we want to cleanup the names of these files, probably we can do that with paired PRs between vinca and the ros-* repos.