### PR TITLE
Normalize licenses as they occur in ROS Humble packages

### DIFF
--- a/vinca/license_utils.py
+++ b/vinca/license_utils.py
@@ -14,16 +14,24 @@ LICENSE_LOOKUP: Dict[str, str] = {
     "bsd-3": "BSD-3-Clause",
     "bsd 3-clause": "BSD-3-Clause",
     "3-clause bsd": "BSD-3-Clause",
+    "bsd clause 3": "BSD-3-Clause",
+    "bsd 3 clause": "BSD-3-Clause",
+    "bsd 3-clause license": "BSD-3-Clause",
+    "bds-3": "BSD-3-Clause",
     "bsd 2-clause": "BSD-2-Clause",
     "bsd license 2.0": "BSD-2-Clause",
     # Apache variants
     "apache": "Apache-2.0",
     "apache 2": "Apache-2.0",
+    "apache-2": "Apache-2.0",
     "apache2": "Apache-2.0",
     "apache2.0": "Apache-2.0",
     "apache 2.0": "Apache-2.0",
+    "apache 2.0 license": "Apache-2.0",
     "apache license 2.0": "Apache-2.0",
     "apache license, version 2.0": "Apache-2.0",
+    "apache-2.0 license": "Apache-2.0",
+    "alv2": "Apache-2.0",
     # GPL variants
     "gplv2": "GPL-2.0-only",
     "gpl-2": "GPL-2.0-only",
@@ -42,13 +50,18 @@ LICENSE_LOOKUP: Dict[str, str] = {
     "lgplv2.1": "LGPL-2.1-or-later",
     "lgpl-2": "LGPL-2.1-or-later",
     "lgpl-2.1": "LGPL-2.1-or-later",
+    "lgpl v2.1": "LGPL-2.1-or-later",
     "lgplv3": "LGPL-3.0-only",
     "lgpl-3": "LGPL-3.0-only",
     "lgpl-3.0": "LGPL-3.0-only",
+    "lgpl-v3": "LGPL-3.0-only",
     "LGPL (amcl)": "LGPL-2.1-or-later",
+    "gnu lesser public license 2.1": "LGPL-2.1-only",
     # Mozilla/MPL variants
     "mozilla": "MPL-2.0",
     "mpl": "MPL-2.0",
+    "mpl-2.0 license": "MPL-2.0",
+    "mozilla public license 2.0": "MPL-2.0",
     "mozilla public license version 1.1": "MPL-1.1",
     # Eclipse variants
     "eclipse public license 2.0": "EPL-2.0",
@@ -63,7 +76,9 @@ LICENSE_LOOKUP: Dict[str, str] = {
     "zlib license": "Zlib",
     # Creative Commons
     "cc by-nc-sa 4.0": "CC-BY-NC-SA-4.0",
+    "cc0": "CC0-1.0",
     "creative commons zero v1.0 universal": "CC0-1.0",
+    "creative commons attribution-noncommercial-noderivatives 4.0 international public license": "CC-BY-NC-ND-4.0",
     "creative commons": "CC0-1.0",  # The version is an assumption
     # Public Domain (choosing Unlicense as more appropriate for code)
     "public domain": "Unlicense",

--- a/vinca/test_license_utils.py
+++ b/vinca/test_license_utils.py
@@ -212,6 +212,12 @@ def test_case_insensitive_lookup():
 
 def test_new_license_variants():
     """Test newly added common license variants."""
+    # BSD variants
+    assert convert_to_spdx_license(["BSD Clause 3"]) == "BSD-3-Clause"
+    assert convert_to_spdx_license(["BDS-3"]) == "BSD-3-Clause"
+    assert convert_to_spdx_license(["BSD 3-Clause License"]) == "BSD-3-Clause"
+    assert convert_to_spdx_license(["BSD 3 Clause"]) == "BSD-3-Clause"
+
     # GPL variants
     assert convert_to_spdx_license(["GPLv2"]) == "GPL-2.0-only"
     assert convert_to_spdx_license(["GPL-2"]) == "GPL-2.0-only"
@@ -221,7 +227,10 @@ def test_new_license_variants():
     assert convert_to_spdx_license(["LGPL"]) == "LGPL-2.1-or-later"
     assert convert_to_spdx_license(["LGPLv2"]) == "LGPL-2.1-or-later"
     assert convert_to_spdx_license(["LGPL-2.1"]) == "LGPL-2.1-or-later"
+    assert convert_to_spdx_license(["LGPL v2.1"]) == "LGPL-2.1-or-later"
     assert convert_to_spdx_license(["LGPLv3"]) == "LGPL-3.0-only"
+    assert convert_to_spdx_license(["LGPL-v3"]) == "LGPL-3.0-only"
+    assert convert_to_spdx_license(["GNU Lesser Public License 2.1"]) == "LGPL-2.1-only"
 
     # AGPL variants
     assert convert_to_spdx_license(["AGPLv3"]) == "AGPL-3.0-only"
@@ -234,6 +243,26 @@ def test_new_license_variants():
 
     # MIT variants
     assert convert_to_spdx_license(["MIT License"]) == "MIT"
+
+    # Apache variants
+    assert convert_to_spdx_license(["Apache-2"]) == "Apache-2.0"
+    assert convert_to_spdx_license(["Apache 2.0 License"]) == "Apache-2.0"
+    assert convert_to_spdx_license(["ALv2"]) == "Apache-2.0"
+
+    # MPL variants
+    assert convert_to_spdx_license(["MPL-2.0 license"]) == "MPL-2.0"
+    assert convert_to_spdx_license(["Mozilla Public License 2.0"]) == "MPL-2.0"
+
+    # Creative Commons variants
+    assert (
+        convert_to_spdx_license(
+            [
+                "Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License"
+            ]
+        )
+        == "CC-BY-NC-ND-4.0"
+    )
+    assert convert_to_spdx_license(["CC0"]) == "CC0-1.0"
 
     # Public Domain
     assert convert_to_spdx_license(["Public Domain"]) == "Unlicense"


### PR DESCRIPTION
In https://github.com/RoboStack/ros-humble/pull/375 I ported ros-humble to the latest vinca, and I got a lot of warnings related to unexpected licenses, so I added a few normalization rules to handle the licenses I saw in ROS Humble.