### PR TITLE
Add env var for CMake build dir to avoid too long path on Windows

### DIFF
--- a/vinca/generate_gha.py
+++ b/vinca/generate_gha.py
@@ -370,7 +370,10 @@ def build_win_pipeline(stages, trigger_branch, outfile="win.yml", azure_template
                 "runs-on": vm_imagename,
                 "strategy": {"fail-fast": False},
                 "needs": prev_batch_keys,
-                "env": [{"CONDA_BLD_PATH": "C:\\\\bld\\\\"},{"VINCA_CUSTOM_CMAKE_BUILD_DIR": "C:\\\\x\\\\"}],
+                "env": [
+                    {"CONDA_BLD_PATH": "C:\\\\bld\\\\"},
+                    {"VINCA_CUSTOM_CMAKE_BUILD_DIR": "C:\\\\x\\\\"},
+                ],
                 "steps": [
                     {"name": "Checkout code", "uses": "actions/checkout@v6"},
                     {

--- a/vinca/generate_gha.py
+++ b/vinca/generate_gha.py
@@ -370,7 +370,7 @@ def build_win_pipeline(stages, trigger_branch, outfile="win.yml", azure_template
                 "runs-on": vm_imagename,
                 "strategy": {"fail-fast": False},
                 "needs": prev_batch_keys,
-                "env": {"CONDA_BLD_PATH": "C:\\\\bld\\\\"},
+                "env": [{"CONDA_BLD_PATH": "C:\\\\bld\\\\"},{"VINCA_CUSTOM_CMAKE_BUILD_DIR": "C:\\\\x\\\\"}],
                 "steps": [
                     {"name": "Checkout code", "uses": "actions/checkout@v6"},
                     {

--- a/vinca/templates/bld_ament_cmake.bat.in
+++ b/vinca/templates/bld_ament_cmake.bat.in
@@ -10,8 +10,8 @@ set CXX=cl.exe
 
 :: If defined, can use a custom CMake build directory which can be useful
 :: to avoid too long path problems on windows
-if defined CUSTOM_CMAKE_BUILD_DIR (
-    cd /d "%CUSTOM_CMAKE_BUILD_DIR%"
+if defined VINCA_CUSTOM_CMAKE_BUILD_DIR (
+    cd /d "%VINCA_CUSTOM_CMAKE_BUILD_DIR%"
 )
 rd /s /q build
 mkdir build

--- a/vinca/templates/bld_ament_cmake.bat.in
+++ b/vinca/templates/bld_ament_cmake.bat.in
@@ -8,6 +8,11 @@ set "PYTHONPATH=%LIBRARY_PREFIX%\lib\site-packages;%SP_DIR%"
 set CC=cl.exe
 set CXX=cl.exe
 
+:: If defined, can use a custom CMake build directory which can be useful
+:: to avoid too long path problems on windows
+if defined CUSTOM_CMAKE_BUILD_DIR (
+    cd /d "%CUSTOM_CMAKE_BUILD_DIR%"
+)
 rd /s /q build
 mkdir build
 pushd build

--- a/vinca/templates/build_ament_cmake.sh.in
+++ b/vinca/templates/build_ament_cmake.sh.in
@@ -3,6 +3,9 @@
 
 set -eo pipefail
 
+if [[ -n "$VINCA_CUSTOM_CMAKE_BUILD_DIR" ]]; then
+    cd "$VINCA_CUSTOM_CMAKE_BUILD_DIR"
+fi
 rm -rf build
 mkdir build
 cd build


### PR DESCRIPTION
If the environment variable `CUSTOM_CMAKE_BUILD_DIR` is set on Windows, then it will be used as root build directory for CMake builds (thus in `%CUSTOM_CMAKE_BUILD_DIR%\build`). This can be used to avoid as much as possible compilation failure on Windows due to too long paths (such as we had here https://github.com/RoboStack/ros-humble/pull/387#issuecomment-4017446764), if `%CUSTOM_CMAKE_BUILD_DIR%` set to a short enough path.
