### PR TITLE
Create VINCA_CUSTOM_CMAKE_BUILD_DIR directory if not exists

### DIFF
--- a/vinca/templates/bld_ament_cmake.bat.in
+++ b/vinca/templates/bld_ament_cmake.bat.in
@@ -11,6 +11,9 @@ set CXX=cl.exe
 :: If defined, can use a custom CMake build directory which can be useful
 :: to avoid too long path problems on windows
 if defined VINCA_CUSTOM_CMAKE_BUILD_DIR (
+    if not exist "%VINCA_CUSTOM_CMAKE_BUILD_DIR%\" (
+        mkdir "%VINCA_CUSTOM_CMAKE_BUILD_DIR%"
+    )
     cd /d "%VINCA_CUSTOM_CMAKE_BUILD_DIR%"
 )
 rd /s /q build

--- a/vinca/templates/build_ament_cmake.sh.in
+++ b/vinca/templates/build_ament_cmake.sh.in
@@ -4,6 +4,7 @@
 set -eo pipefail
 
 if [[ -n "$VINCA_CUSTOM_CMAKE_BUILD_DIR" ]]; then
+    mkdir -p "$VINCA_CUSTOM_CMAKE_BUILD_DIR"
     cd "$VINCA_CUSTOM_CMAKE_BUILD_DIR"
 fi
 rm -rf build


### PR DESCRIPTION
This completes #115 which was adding a feature to use `VINCA_CUSTOM_CMAKE_BUILD_DIR` env var as CMake build dir if set.
However, if the variable is set but the directory does not, this will just skip this and give no error as it.
We could either enforce the corresponding directory to be created first (and add a test here), or create the corresponding directory here if not already existing, which is what this PR propose.
Sorry to have missed that in #115.