### PR TITLE
Apply patches in a deterministic order

### DIFF
--- a/vinca/main.py
+++ b/vinca/main.py
@@ -190,7 +190,7 @@ def read_vinca_yaml(filepath):
     vinca_conf["_patch_dir"] = patch_dir
     patches = {}
 
-    for x in glob.glob(os.path.join(vinca_conf["_patch_dir"], "*.patch")):
+    for x in sorted(glob.glob(os.path.join(vinca_conf["_patch_dir"], "*.patch"))):
         splitted = os.path.basename(x).split(".")
         if splitted[0] not in patches:
             patches[splitted[0]] = {


### PR DESCRIPTION
The patches of a package are collected with `glob.glob()`, which returns the directory entries in filesystem order.

Two patches of the same package can therefore end up in either order depending on the machine and on the run. That produces a spurious diff every time the recipes are regenerated, and, more importantly, it can apply a `0002-` patch before the `0001-` one, which is exactly the order those prefixes are meant to express.

I hit this with two patches on the same package: regenerating the recipes on a different machine swapped the two entries in the generated `recipe.yaml`.

Sorting the glob result is enough to make the order deterministic and lexicographic.

**Tested**

- `pytest` on the repo: 113 passed.
- Regenerated an overlay with two patches on one package several times and on two different machines: the generated `source.patches` list is now stable.
