### PR TITLE
fix: handle pinning edge cases

### DIFF
--- a/vinca/distro.py
+++ b/vinca/distro.py
@@ -5,6 +5,7 @@ import tarfile
 import urllib.parse
 import zipfile
 from concurrent.futures import ThreadPoolExecutor
+from typing import Iterable, Optional
 
 import requests
 from rosdistro import get_cached_distribution, get_index, get_index_url
@@ -142,7 +143,9 @@ class Distro(object):
     def add_packages(self, packages):
         self.build_packages = set(packages)
 
-    def get_depends(self, pkg, ignore_pkgs=None):
+    def get_depends(
+        self, pkg: str, ignore_pkgs: Optional[Iterable[str]] = None
+    ) -> set[str]:
         cache_key = (pkg, tuple(sorted(ignore_pkgs)) if ignore_pkgs else None)
         if cache_key in self._depends_cache:
             return set(self._depends_cache[cache_key])
@@ -172,7 +175,7 @@ class Distro(object):
         self._depends_cache[cache_key] = set(dependencies)
         return dependencies
 
-    def _get_direct_depends(self, pkg):
+    def _get_direct_depends(self, pkg: str) -> set[str]:
         """Return direct dependencies, caching package metadata across root walks."""
 
         if pkg in self._direct_depends_cache:
@@ -329,7 +332,7 @@ class Distro(object):
             return self._download_raw_pkg_xml_or_cached(url=raw_url)
         raise RuntimeError(f"Cannot handle unknown repository hoster: {raw_url_base}")
 
-    def prefetch_additional_package_xml(self, max_workers=12):
+    def prefetch_additional_package_xml(self, max_workers: int = 12) -> None:
         """Fetch immutable raw manifests concurrently for dependency discovery."""
 
         package_infos = [

--- a/vinca/distro.py
+++ b/vinca/distro.py
@@ -153,13 +153,15 @@ class Distro(object):
 
         ignore_pkgs = set(ignore_pkgs or ())
         dependencies = set()
+        visited = {pkg}
         packages_to_check = {pkg}
         while packages_to_check:
             current = packages_to_check.pop()
             if current in ignore_pkgs:
                 continue
             direct = self._get_direct_depends(current) - ignore_pkgs
-            new_dependencies = direct - dependencies
+            new_dependencies = direct - visited
+            visited.update(new_dependencies)
             dependencies.update(new_dependencies)
             packages_to_check.update(
                 dependency

--- a/vinca/main.py
+++ b/vinca/main.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 
+from __future__ import annotations
+
 import argparse
 import catkin_pkg
 import sys
 import os
 import glob
 import platform
+from typing import Any, Optional
+
 import ruamel.yaml
 from pathlib import Path
 
@@ -308,14 +312,14 @@ def append_output_with_compatibility(
 
 
 def generate_output(
-    pkg_shortname,
-    vinca_conf,
-    distro,
-    version,
-    all_pkgs=None,
+    pkg_shortname: str,
+    vinca_conf: dict[str, Any],
+    distro: Distro,
+    version: str,
+    all_pkgs: Optional[list[Any]] = None,
     *,
-    dependencies_only=False,
-):
+    dependencies_only: bool = False,
+) -> Optional[dict[str, Any]]:
     if not all_pkgs:
         all_pkgs = []
 
@@ -667,7 +671,7 @@ def generate_output(
     return output
 
 
-def get_group_dependency_packages(distro):
+def get_group_dependency_packages(distro: Distro) -> list[Any]:
     """Parse the packages needed to expand package.xml group dependencies."""
 
     packages = []
@@ -681,7 +685,9 @@ def get_group_dependency_packages(distro):
     return packages
 
 
-def generate_dependency_requirements(distro, vinca_conf, all_pkgs):
+def generate_dependency_requirements(
+    distro: Distro, vinca_conf: dict[str, Any], all_pkgs: list[Any]
+) -> list[dict[str, Any]]:
     """Collect requirement mappings without generating complete recipe outputs."""
 
     requirements = []

--- a/vinca/pinning.py
+++ b/vinca/pinning.py
@@ -363,37 +363,45 @@ def dependencies_from_vinca(base_dir, platforms=DEFAULT_PLATFORMS):
     dependencies = set()
     distro = None
     group_packages = None
-    with _working_directory(base_dir):
-        for platform in platforms:
-            config.selected_platform = platform
-            config.parsed_args = argparse.Namespace(platform=platform)
-            vinca_config = read_vinca_yaml(base_dir / "vinca.yaml")
-            vinca_config["skip_built_packages"] = []
-            if distro is None:
-                distro = Distro(
-                    vinca_config["ros_distro"],
-                    vinca_config.get("python_version"),
-                    vinca_config["_snapshot"],
-                    vinca_config["_additional_packages_snapshot"],
+    previous_platform = config.selected_platform
+    previous_args = config.parsed_args
+    try:
+        with _working_directory(base_dir):
+            for platform in platforms:
+                config.selected_platform = platform
+                config.parsed_args = argparse.Namespace(platform=platform)
+                vinca_config = read_vinca_yaml(base_dir / "vinca.yaml")
+                vinca_config["skip_built_packages"] = []
+                if distro is None:
+                    distro = Distro(
+                        vinca_config["ros_distro"],
+                        vinca_config.get("python_version"),
+                        vinca_config["_snapshot"],
+                        vinca_config["_additional_packages_snapshot"],
+                    )
+                    distro.prefetch_additional_package_xml()
+                    group_packages = get_group_dependency_packages(distro)
+                elif (
+                    distro.name != vinca_config["ros_distro"]
+                    or distro.snapshot != vinca_config["_snapshot"]
+                    or distro.additional_packages_snapshot
+                    != vinca_config["_additional_packages_snapshot"]
+                ):
+                    raise PinningError(
+                        "Platform selectors must not change the ROS distro snapshots"
+                    )
+                vinca_config["_selected_pkgs"] = get_selected_packages(
+                    distro, vinca_config
                 )
-                distro.prefetch_additional_package_xml()
-                group_packages = get_group_dependency_packages(distro)
-            elif (
-                distro.name != vinca_config["ros_distro"]
-                or distro.snapshot != vinca_config["_snapshot"]
-                or distro.additional_packages_snapshot
-                != vinca_config["_additional_packages_snapshot"]
-            ):
-                raise PinningError(
-                    "Platform selectors must not change the ROS distro snapshots"
-                )
-            vinca_config["_selected_pkgs"] = get_selected_packages(distro, vinca_config)
-            for requirement_group in generate_dependency_requirements(
-                distro, vinca_config, group_packages
-            ):
-                for requirement in _walk_requirements(requirement_group):
-                    if name := _dependency_name(requirement):
-                        dependencies.add(name)
+                for requirement_group in generate_dependency_requirements(
+                    distro, vinca_config, group_packages
+                ):
+                    for requirement in _walk_requirements(requirement_group):
+                        if name := _dependency_name(requirement):
+                            dependencies.add(name)
+    finally:
+        config.selected_platform = previous_platform
+        config.parsed_args = previous_args
     return dependencies
 
 

--- a/vinca/pinning.py
+++ b/vinca/pinning.py
@@ -8,6 +8,8 @@ on top of it, and local overrides.  This module turns that small file into the
 
 from __future__ import annotations
 
+from typing import Any, Iterator, Mapping, Optional, Sequence, Union
+
 import argparse
 import io
 import json
@@ -59,14 +61,14 @@ class PinningError(RuntimeError):
     """A pinning file could not be downloaded, interpreted, or updated."""
 
 
-def _yaml():
+def _yaml() -> Any:
     yaml = ruamel.yaml.YAML()
     yaml.width = 4096
     yaml.indent(mapping=2, sequence=4, offset=2)
     return yaml
 
 
-def _request(url, *, timeout=120):
+def _request(url: str, *, timeout: int = 120) -> Any:
     try:
         response = requests.get(url, timeout=timeout)
         response.raise_for_status()
@@ -75,7 +77,7 @@ def _request(url, *, timeout=120):
     return response
 
 
-def _load_zstd_json(payload):
+def _load_zstd_json(payload: bytes) -> Any:
     try:
         decompressed = zstandard.ZstdDecompressor().decompress(payload)
     except zstandard.ZstdError as exc:
@@ -83,7 +85,7 @@ def _load_zstd_json(payload):
     return json.loads(decompressed)
 
 
-def get_latest_pinning_distribution():
+def get_latest_pinning_distribution() -> tuple[str, str]:
     """Return the newest conda-forge-pinning version and artifact URL."""
     repodata = _load_zstd_json(_request(CURRENT_REPODATA_URL).content)
     records = []
@@ -100,7 +102,7 @@ def get_latest_pinning_distribution():
     return str(record["version"]), url
 
 
-def get_pinning_distribution(version):
+def get_pinning_distribution(version: str) -> str:
     """Return the artifact URL for an exact conda-forge-pinning version."""
     release = _request(ANACONDA_RELEASE_URL.format(version=quote(str(version)))).json()
     distributions = [
@@ -127,7 +129,7 @@ def get_pinning_distribution(version):
     return url
 
 
-def _read_tar_members(fileobj, *, mode):
+def _read_tar_members(fileobj: Any, *, mode: str) -> dict[str, bytes]:
     files = {}
     with tarfile.open(fileobj=fileobj, mode=mode) as archive:
         for member in archive:
@@ -144,7 +146,7 @@ def _read_tar_members(fileobj, *, mode):
     return files
 
 
-def _read_pinning_package(payload):
+def _read_pinning_package(payload: bytes) -> tuple[bytes, dict[str, bytes]]:
     """Read the base config and migrations from a .conda or .tar.bz2 payload."""
     stream = io.BytesIO(payload)
     if zipfile.is_zipfile(stream):
@@ -177,12 +179,16 @@ def _read_pinning_package(payload):
     return base, migrations
 
 
-def download_pinning_package(version, *, artifact_url=None):
+def download_pinning_package(
+    version: str, *, artifact_url: Optional[str] = None
+) -> tuple[bytes, dict[str, bytes]]:
     url = artifact_url or get_pinning_distribution(version)
     return _read_pinning_package(_request(url).content)
 
 
-def _pinning_spec_fields(data):
+def _pinning_spec_fields(
+    data: Mapping[str, Any],
+) -> tuple[str, list[str], Mapping[str, Any]]:
     version = data.get("conda_forge_pinning_version")
     migrations = data.get("migrations", [])
     overrides = data.get("pinning_overrides")
@@ -199,26 +205,26 @@ def _pinning_spec_fields(data):
     return str(version), migrations, overrides
 
 
-def _migration_name(name):
+def _migration_name(name: str) -> str:
     name = name.removesuffix(".yaml")
     if not re.fullmatch(r"[A-Za-z0-9_.-]+", name):
         raise PinningError(f"Invalid migration name: {name!r}")
     return name
 
 
-def _overlay(target, source):
+def _overlay(target: Any, source: Any) -> None:
     for key, value in source.items():
         if key == "migrator_ts" or str(key).startswith("__"):
             continue
         target[key] = value
 
 
-def _migration_timestamp(payload):
+def _migration_timestamp(payload: bytes) -> float:
     data = _yaml().load(payload.decode("utf-8")) or {}
     return float(data.get("migrator_ts", -1.0))
 
 
-def _validate_zipped_overrides(rendered, overrides):
+def _validate_zipped_overrides(rendered: Any, overrides: Any) -> None:
     override_keys = set(overrides)
     for group in rendered.get("zip_keys", []):
         group = set(group)
@@ -232,7 +238,7 @@ def _validate_zipped_overrides(rendered, overrides):
             )
 
 
-def _format_rendered_yaml(payload):
+def _format_rendered_yaml(payload: str) -> str:
     """Normalize emitted YAML while preserving selectors on empty list items."""
 
     lines = payload.splitlines()
@@ -254,7 +260,12 @@ def _format_rendered_yaml(payload):
     return "\n".join(formatted) + "\n"
 
 
-def render_pinning(config_path, output_path, *, package=None):
+def render_pinning(
+    config_path: Union[str, Path],
+    output_path: Union[str, Path],
+    *,
+    package: Optional[tuple[bytes, Mapping[str, bytes]]] = None,
+) -> Any:
     """Render vinca_pinning.yaml into conda_build_config.yaml."""
     yaml = _yaml()
     config_path = Path(config_path)
@@ -301,7 +312,7 @@ def render_pinning(config_path, output_path, *, package=None):
     return rendered
 
 
-def _dependency_name(requirement):
+def _dependency_name(requirement: Any) -> Optional[str]:
     if not isinstance(requirement, str) or requirement.startswith("${{"):
         return None
     name = requirement.split()[0]
@@ -310,7 +321,7 @@ def _dependency_name(requirement):
     return name
 
 
-def _walk_requirements(value):
+def _walk_requirements(value: Any) -> Iterator[str]:
     if isinstance(value, str):
         yield value
     elif isinstance(value, list):
@@ -325,7 +336,7 @@ def _walk_requirements(value):
             yield from _walk_requirements(item)
 
 
-def dependencies_from_recipes(recipe_dir):
+def dependencies_from_recipes(recipe_dir: Union[str, Path]) -> set[str]:
     """Collect non-ROS conda dependency names from generated recipe files."""
     yaml = _yaml()
     dependencies = set()
@@ -339,7 +350,7 @@ def dependencies_from_recipes(recipe_dir):
 
 
 @contextmanager
-def _working_directory(path):
+def _working_directory(path: Any) -> Iterator[None]:
     previous = Path.cwd()
     os.chdir(path)
     try:
@@ -348,7 +359,9 @@ def _working_directory(path):
         os.chdir(previous)
 
 
-def dependencies_from_vinca(base_dir, platforms=DEFAULT_PLATFORMS):
+def dependencies_from_vinca(
+    base_dir: Union[str, Path], platforms: Sequence[str] = DEFAULT_PLATFORMS
+) -> set[str]:
     """Collect would-be recipe dependencies while reusing one distro model."""
     from vinca import config
     from vinca.distro import Distro
@@ -405,11 +418,11 @@ def dependencies_from_vinca(base_dir, platforms=DEFAULT_PLATFORMS):
     return dependencies
 
 
-def _normalized(name):
+def _normalized(name: str) -> str:
     return name.lower().replace("_", "-")
 
 
-def _feedstock_output_url(package):
+def _feedstock_output_url(package: str) -> str:
     prefix = (package.lower() + "zzz")[:3]
     shards = "/".join(prefix)
     return FEEDSTOCK_OUTPUT_URL.format(
@@ -417,7 +430,7 @@ def _feedstock_output_url(package):
     )
 
 
-def package_feedstocks(package):
+def package_feedstocks(package: str) -> set[str]:
     """Return feedstocks producing a conda package, with a conservative fallback."""
     url = _feedstock_output_url(package)
     try:
@@ -431,7 +444,7 @@ def package_feedstocks(package):
     return set(feedstocks) or {package}
 
 
-def get_migration_status(migration):
+def get_migration_status(migration: str) -> Optional[dict[str, Any]]:
     url = MIGRATION_STATUS_URL.format(migration=quote(migration.lower(), safe=""))
     try:
         response = requests.get(url, timeout=60)
@@ -445,7 +458,7 @@ def get_migration_status(migration):
         ) from exc
 
 
-def _migration_pin_keys(payload):
+def _migration_pin_keys(payload: bytes) -> set[str]:
     data = _yaml().load(payload.decode("utf-8")) or {}
     return {
         _normalized(str(key))
@@ -454,19 +467,19 @@ def _migration_pin_keys(payload):
     }
 
 
-def _is_paused_migration(payload):
+def _is_paused_migration(payload: bytes) -> bool:
     data = _yaml().load(payload.decode("utf-8")) or {}
     return bool((data.get("__migrator") or {}).get("paused", False))
 
 
-def _comment_selector(comment):
+def _comment_selector(comment: Any) -> Optional[str]:
     if comment is None:
         return None
     match = re.search(r"#\s*\[(.+)]", comment.value)
     return match.group(1) if match else None
 
 
-def _migration_selectors(data):
+def _migration_selectors(data: Any) -> Iterator[Optional[str]]:
     """Yield selector expressions for each top-level variant value."""
     for key, value in data.items():
         if key == "migrator_ts" or str(key).startswith("__"):
@@ -485,7 +498,7 @@ def _migration_selectors(data):
             yield key_selector
 
 
-def _migration_applies_to_platforms(payload, platforms):
+def _migration_applies_to_platforms(payload: bytes, platforms: Sequence[str]) -> bool:
     data = _yaml().load(payload.decode("utf-8")) or {}
     migrator = data.get("__migrator") or {}
     allowlist = set(migrator.get("platform_allowlist", []))
@@ -501,7 +514,7 @@ def _migration_applies_to_platforms(payload, platforms):
     )
 
 
-def _status_sets(status):
+def _status_sets(status: Any) -> tuple[set[str], set[str]]:
     values = {
         category: {_normalized(name) for name in status.get(category, [])}
         for category in STATUS_CATEGORIES
@@ -511,8 +524,11 @@ def _status_sets(status):
 
 
 def select_completed_migrations(
-    migration_payloads, dependencies, existing_migrations=(), platforms=None
-):
+    migration_payloads: Mapping[str, bytes],
+    dependencies: set[str],
+    existing_migrations: Sequence[str] = (),
+    platforms: Optional[Sequence[str]] = None,
+) -> tuple[list[str], list[tuple[str, str]]]:
     """Select active migrations completed for all relevant dependency feedstocks."""
     existing = {_migration_name(name) for name in existing_migrations}
     candidates = {
@@ -586,13 +602,13 @@ def select_completed_migrations(
 
 
 def update_pinning(
-    config_path,
+    config_path: Union[str, Path],
     *,
-    base_dir=None,
-    platforms=DEFAULT_PLATFORMS,
-    dependencies=None,
-    latest_distribution=None,
-):
+    base_dir: Optional[Union[str, Path]] = None,
+    platforms: Sequence[str] = DEFAULT_PLATFORMS,
+    dependencies: Optional[set[str]] = None,
+    latest_distribution: Optional[tuple[str, str]] = None,
+) -> tuple[str, list[str], list[tuple[str, str]]]:
     """Update the base version and completed active migrations in a pinning spec."""
     config_path = Path(config_path)
     base_dir = Path(base_dir or config_path.parent)
@@ -634,7 +650,7 @@ def update_pinning(
     return version, migrations, reports
 
 
-def _common_parser(description):
+def _common_parser(description: str) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         "-d", "--dir", default=".", help="RoboStack repository directory"
@@ -647,7 +663,7 @@ def _common_parser(description):
     return parser
 
 
-def render_main(argv=None):
+def render_main(argv: Optional[Sequence[str]] = None) -> None:
     parser = _common_parser("Render conda_build_config.yaml from vinca pinning")
     parser.add_argument(
         "-o",
@@ -664,7 +680,7 @@ def render_main(argv=None):
     print(f"Rendered {base_dir / args.output}")
 
 
-def update_main(argv=None):
+def update_main(argv: Optional[Sequence[str]] = None) -> None:
     parser = _common_parser("Update vinca pinning from conda-forge migration status")
     parser.add_argument(
         "--platform",

--- a/vinca/test_distro_dependencies.py
+++ b/vinca/test_distro_dependencies.py
@@ -53,6 +53,18 @@ def test_dependency_walk_honors_ignored_packages():
     assert distro.get_depends("app", ignore_pkgs={"ignored"}) == {"included"}
 
 
+def test_dependency_walk_excludes_root_in_cycles():
+    graph = {"a": {"b"}, "b": {"a"}}
+    distro = Distro.__new__(Distro)
+    distro._depends_cache = {}
+    distro._direct_depends_cache = {}
+    distro.additional_packages_snapshot = None
+    distro.check_package = lambda name: name in graph
+    distro._get_direct_depends = lambda name: graph[name]
+
+    assert distro.get_depends("a") == {"b"}
+
+
 def test_prefetch_additional_manifests_skips_archives():
     distro = Distro.__new__(Distro)
     distro.additional_packages_snapshot = {

--- a/vinca/test_distro_dependencies.py
+++ b/vinca/test_distro_dependencies.py
@@ -65,6 +65,29 @@ def test_dependency_walk_excludes_root_in_cycles():
     assert distro.get_depends("a") == {"b"}
 
 
+def test_dependency_walk_excludes_root_from_self_dependency():
+    distro = Distro.__new__(Distro)
+    distro._depends_cache = {}
+    distro._direct_depends_cache = {}
+    distro.additional_packages_snapshot = None
+    distro.check_package = lambda name: name == "a"
+    distro._get_direct_depends = lambda name: {"a"}
+
+    assert distro.get_depends("a") == set()
+
+
+def test_dependency_walk_excludes_root_from_longer_cycle():
+    graph = {"a": {"b"}, "b": {"c"}, "c": {"a"}}
+    distro = Distro.__new__(Distro)
+    distro._depends_cache = {}
+    distro._direct_depends_cache = {}
+    distro.additional_packages_snapshot = None
+    distro.check_package = lambda name: name in graph
+    distro._get_direct_depends = lambda name: graph[name]
+
+    assert distro.get_depends("a") == {"b", "c"}
+
+
 def test_prefetch_additional_manifests_skips_archives():
     distro = Distro.__new__(Distro)
     distro.additional_packages_snapshot = {

--- a/vinca/test_pinning.py
+++ b/vinca/test_pinning.py
@@ -18,7 +18,7 @@ from vinca.pinning import (
     select_completed_migrations,
     update_pinning,
 )
-from vinca.variant_algebra import variant_add
+from vinca.variant_algebra import _selector_platforms, variant_add
 
 
 BASE_CONFIG = b"""\
@@ -208,6 +208,32 @@ def test_cfep9_merges_pin_run_as_build_and_zip_keys():
     assert merged["zip_keys"] == [["is_python_min", "numpy", "python"]]
 
 
+def test_cfep9_duplicate_primary_values_keep_zip_key_columns_aligned():
+    merged = variant_add(
+        {
+            "python": ["3.13"],
+            "numpy": ["1.0"],
+            "zip_keys": [["python", "numpy"]],
+        },
+        {
+            "__migrator": {"primary_key": "python"},
+            "python": ["3.13"],
+            "numpy": ["2.0"],
+        },
+    )
+
+    assert len(merged["python"]) == len(merged["numpy"])
+
+
+def test_cfep9_negated_platform_selector_keeps_non_negated_platforms():
+    assert _selector_platforms("not win") == {
+        "linux-64",
+        "linux-aarch64",
+        "osx-64",
+        "osx-arm64",
+    }
+
+
 def test_cfep9_scoped_migration_only_replaces_matching_platform_values():
     yaml = ruamel.yaml.YAML()
     base = yaml.load(
@@ -261,6 +287,43 @@ requirements:
         "libcamera",
         "python",
     }
+
+
+def test_dependencies_from_vinca_restores_global_platform_configuration(tmp_path, monkeypatch):
+    from vinca import config
+
+    distro = type(
+        "FakeDistro",
+        (),
+        {
+            "name": "rolling",
+            "snapshot": {},
+            "additional_packages_snapshot": {},
+            "prefetch_additional_package_xml": lambda self: None,
+        },
+    )()
+    original_args = object()
+    monkeypatch.setattr(config, "selected_platform", "osx-64")
+    monkeypatch.setattr(config, "parsed_args", original_args)
+
+    with (
+        patch("vinca.distro.Distro", return_value=distro),
+        patch(
+            "vinca.main.read_vinca_yaml",
+            return_value={
+                "ros_distro": "rolling",
+                "_snapshot": {},
+                "_additional_packages_snapshot": {},
+            },
+        ),
+        patch("vinca.main.get_group_dependency_packages", return_value=[]),
+        patch("vinca.main.get_selected_packages", return_value=[]),
+        patch("vinca.main.generate_dependency_requirements", return_value=[]),
+    ):
+        dependencies_from_vinca(tmp_path, platforms=("linux-64",))
+
+    assert config.selected_platform == "osx-64"
+    assert config.parsed_args is original_args
 
 
 def test_dependencies_from_vinca_reuses_distro_and_group_packages(tmp_path):

--- a/vinca/test_pinning.py
+++ b/vinca/test_pinning.py
@@ -234,6 +234,38 @@ def test_cfep9_negated_platform_selector_keeps_non_negated_platforms():
     }
 
 
+@pytest.mark.parametrize(
+    ("selector", "platforms"),
+    [
+        ("not linux", {"osx-64", "osx-arm64", "win-64"}),
+        ("not osx", {"linux-64", "linux-aarch64", "win-64"}),
+        ("not win", {"linux-64", "linux-aarch64", "osx-64", "osx-arm64"}),
+        ("unix and not osx", {"linux-64", "linux-aarch64"}),
+        ("not win and x86_64", {"linux-64", "osx-64"}),
+    ],
+)
+def test_cfep9_negated_selectors_keep_the_remaining_platforms(selector, platforms):
+    assert _selector_platforms(selector) == platforms
+
+
+def test_cfep9_repeated_complete_zip_row_keeps_one_aligned_row():
+    merged = variant_add(
+        {
+            "python": ["3.13"],
+            "numpy": ["1.0"],
+            "zip_keys": [["python", "numpy"]],
+        },
+        {
+            "__migrator": {"primary_key": "python"},
+            "python": ["3.13"],
+            "numpy": ["1.0"],
+        },
+    )
+
+    assert merged["python"] == ["3.13"]
+    assert merged["numpy"] == ["1.0"]
+
+
 def test_cfep9_scoped_migration_only_replaces_matching_platform_values():
     yaml = ruamel.yaml.YAML()
     base = yaml.load(
@@ -319,6 +351,33 @@ def test_dependencies_from_vinca_restores_global_platform_configuration(tmp_path
         patch("vinca.main.get_group_dependency_packages", return_value=[]),
         patch("vinca.main.get_selected_packages", return_value=[]),
         patch("vinca.main.generate_dependency_requirements", return_value=[]),
+    ):
+        dependencies_from_vinca(tmp_path, platforms=("linux-64",))
+
+    assert config.selected_platform == "osx-64"
+    assert config.parsed_args is original_args
+
+
+def test_dependencies_from_vinca_restores_global_configuration_on_error(
+    tmp_path, monkeypatch
+):
+    from vinca import config
+
+    original_args = object()
+    monkeypatch.setattr(config, "selected_platform", "osx-64")
+    monkeypatch.setattr(config, "parsed_args", original_args)
+
+    with (
+        patch(
+            "vinca.main.read_vinca_yaml",
+            return_value={
+                "ros_distro": "rolling",
+                "_snapshot": {},
+                "_additional_packages_snapshot": {},
+            },
+        ),
+        patch("vinca.distro.Distro", side_effect=RuntimeError("network failure")),
+        pytest.raises(RuntimeError, match="network failure"),
     ):
         dependencies_from_vinca(tmp_path, platforms=("linux-64",))
 

--- a/vinca/variant_algebra.py
+++ b/vinca/variant_algebra.py
@@ -92,11 +92,16 @@ def _selector_platforms(selector):
     if "unix" in tokens:
         platforms &= {item for item in _PLATFORMS if not item.startswith("win-")}
     os_scopes = []
-    if "linux" in tokens or "linux64" in tokens:
+    def is_positive_os(*names):
+        return any(name in tokens for name in names) and not any(
+            re.search(rf"\bnot\s+{name}\b", selector) for name in names
+        )
+
+    if is_positive_os("linux", "linux64"):
         os_scopes.append({item for item in _PLATFORMS if item.startswith("linux-")})
-    if "osx" in tokens:
+    if is_positive_os("osx"):
         os_scopes.append({item for item in _PLATFORMS if item.startswith("osx-")})
-    if "win" in tokens or "win64" in tokens:
+    if is_positive_os("win", "win64"):
         os_scopes.append({item for item in _PLATFORMS if item.startswith("win-")})
     if os_scopes:
         platforms &= set().union(*os_scopes)
@@ -364,11 +369,16 @@ def variant_add(left, right):
         group = next((group for group in zip_groups if primary_key in group), [])
         if not group:
             continue
-        chosen = [
-            index
-            for index, value in enumerate(primary_left + primary_right)
-            if value in merged
-        ]
+        source_primary = primary_left + primary_right
+        chosen = []
+        for value in merged:
+            chosen.append(
+                next(
+                    index
+                    for index, candidate in enumerate(source_primary)
+                    if candidate == value and index not in chosen
+                )
+            )
         for key in set(group) - {primary_key}:
             values = _ensure_list(left[key]) + _ensure_list(right[key])
             selected = [value for index, value in enumerate(values) if index in chosen]

--- a/vinca/variant_algebra.py
+++ b/vinca/variant_algebra.py
@@ -8,6 +8,8 @@ normal migrations, zip keys, pin_run_as_build, key_add, and key_remove.
 
 from __future__ import annotations
 
+from typing import Any, MutableMapping, Optional
+
 from copy import deepcopy
 import re
 
@@ -25,13 +27,13 @@ _PLATFORMS = {
 }
 
 
-def _ensure_list(value):
+def _ensure_list(value: Any) -> list[Any]:
     if isinstance(value, list):
         return value
     return [value]
 
 
-def _version_order(value, ordering=None):
+def _version_order(value: Any, ordering: Any = None) -> tuple[int, Any]:
     if ordering is not None:
         return (2, ordering.index(value))
     normalized = str(value).replace(" ", ".").replace("*", "1")
@@ -41,7 +43,7 @@ def _version_order(value, ordering=None):
         return (0, normalized)
 
 
-def _copy_sequence_comments(values, *sources):
+def _copy_sequence_comments(values: Any, *sources: Any) -> CommentedSeq:
     """Build a round-trip sequence, retaining selector comments where possible."""
     result = CommentedSeq(deepcopy(list(values)))
     used = [set() for _ in sources]
@@ -64,14 +66,14 @@ def _copy_sequence_comments(values, *sources):
     return result
 
 
-def _comment_selector(comment):
+def _comment_selector(comment: Any) -> Optional[str]:
     if comment is None:
         return None
     match = _SELECTOR_RE.search(comment.value)
     return match.group(1) if match else None
 
 
-def _sequence_selector(mapping, key, index):
+def _sequence_selector(mapping: Any, key: str, index: int) -> Optional[str]:
     key_comment = mapping.ca.items.get(key, [None, None, None])[2]
     key_selector = _comment_selector(key_comment)
     value = mapping[key]
@@ -84,7 +86,7 @@ def _sequence_selector(mapping, key, index):
     return key_selector or item_selector
 
 
-def _selector_platforms(selector):
+def _selector_platforms(selector: Optional[str]) -> set[str]:
     if selector is None:
         return set(_PLATFORMS)
     platforms = set(_PLATFORMS)
@@ -92,7 +94,8 @@ def _selector_platforms(selector):
     if "unix" in tokens:
         platforms &= {item for item in _PLATFORMS if not item.startswith("win-")}
     os_scopes = []
-    def is_positive_os(*names):
+
+    def is_positive_os(*names: Any) -> Any:
         return any(name in tokens for name in names) and not any(
             re.search(rf"\bnot\s+{name}\b", selector) for name in names
         )
@@ -118,7 +121,7 @@ def _selector_platforms(selector):
     return platforms
 
 
-def _platform_selector(platforms):
+def _platform_selector(platforms: Any) -> str:
     if platforms == {"linux-64", "linux-aarch64"}:
         return "linux"
     if platforms == {"osx-64", "osx-arm64"}:
@@ -135,7 +138,9 @@ def _platform_selector(platforms):
     return " or ".join(expressions[item] for item in sorted(platforms))
 
 
-def _selector_aware_replace(left_mapping, right_mapping, key):
+def _selector_aware_replace(
+    left_mapping: Any, right_mapping: Any, key: str
+) -> CommentedSeq:
     """Replace only selector scopes present in the migration's sequence."""
     left = left_mapping[key]
     right = right_mapping[key]
@@ -177,7 +182,7 @@ def _selector_aware_replace(left_mapping, right_mapping, key):
     return result
 
 
-def _has_sequence_selectors(mapping, key):
+def _has_sequence_selectors(mapping: Any, key: str) -> bool:
     value = mapping[key]
     return isinstance(value, CommentedSeq) and any(
         _sequence_selector(mapping, key, index) is not None
@@ -185,7 +190,7 @@ def _has_sequence_selectors(mapping, key):
     )
 
 
-def _key_add(left, right, ordering=None):
+def _key_add(left: Any, right: Any, ordering: Any = None) -> CommentedSeq:
     output = []
     common_length = min(len(left), len(right))
     if ordering is None:
@@ -213,12 +218,14 @@ def _key_add(left, right, ordering=None):
     return _copy_sequence_comments(output, left, right)
 
 
-def _set_union(left, right, ordering=None):
+def _set_union(left: Any, right: Any, ordering: Any = None) -> list[Any]:
     values = set(left) | set(right)
     return sorted(values, key=lambda value: _version_order(value, ordering))
 
 
-def _key_add_operation(left, right):
+def _key_add_operation(
+    left: MutableMapping[str, Any], right: MutableMapping[str, Any]
+) -> MutableMapping[str, Any]:
     primary_key = right["__migrator"]["primary_key"]
     additional_zip_keys = right["__migrator"].get("additional_zip_keys", [])
     ordering = right["__migrator"].get("ordering", {})
@@ -284,7 +291,9 @@ def _key_add_operation(left, right):
     return result
 
 
-def _key_remove_operation(left, right):
+def _key_remove_operation(
+    left: MutableMapping[str, Any], right: MutableMapping[str, Any]
+) -> MutableMapping[str, Any]:
     primary_key = right["__migrator"]["primary_key"]
     ordering = right["__migrator"].get("ordering", {})
     if primary_key not in right or primary_key not in left:
@@ -309,7 +318,7 @@ def _key_remove_operation(left, right):
     return result
 
 
-def _merge_zip_keys(left, right):
+def _merge_zip_keys(left: Any, right: Any) -> CommentedSeq:
     output = []
     left_sets = {frozenset(chunk) for chunk in left}
     right_sets = {frozenset(chunk) for chunk in right}
@@ -329,7 +338,9 @@ def _merge_zip_keys(left, right):
     )
 
 
-def variant_add(left, right):
+def variant_add(
+    left: MutableMapping[str, Any], right: MutableMapping[str, Any]
+) -> MutableMapping[str, Any]:
     """Combine two variant mappings with conda-forge's CFEP-9 semantics."""
     operation = (right.get("__migrator") or {}).get("operation")
     if operation == "key_add":


### PR DESCRIPTION
This follows #138. I found a few edge cases in the pinning code that can produce invalid variant configuration or leave global state behind for later Vinca calls in the same process.

This keeps zip-key columns aligned when a migration repeats a primary value, handles negated OS selectors without first treating the negated OS as a positive scope, excludes the root package from cyclic dependency closures, and restores the global platform configuration after dependency discovery.

The first commit adds regressions for each case, the second fixes them, and the third adds more selector, cycle, and failure-path coverage. The last commit adds Python 3.9-compatible annotations to the pinning automation and related production code from #138.

## Testing

- `pixi run ruff format --check vinca/pinning.py vinca/variant_algebra.py vinca/distro.py vinca/main.py`
- `pixi run ruff check vinca/pinning.py vinca/variant_algebra.py vinca/distro.py vinca/main.py`
- `pixi run pytest` (146 passed)