### PR TITLE
fix: move the snapshot branch into get_depends

### DIFF
--- a/vinca/distro.py
+++ b/vinca/distro.py
@@ -156,6 +156,12 @@ class Distro(object):
             return set()
 
         ignore_pkgs = set(ignore_pkgs or ())
+
+        if self.snapshot:
+            dependencies = self._get_snapshot_recursive_depends(pkg, ignore_pkgs)
+            self._depends_cache[cache_key] = set(dependencies)
+            return dependencies
+
         dependencies = set()
         visited = {pkg}
         packages_to_check = {pkg}
@@ -181,11 +187,6 @@ class Distro(object):
 
         if pkg in self._direct_depends_cache:
             return set(self._direct_depends_cache[pkg])
-
-        if self.snapshot:
-            dependencies = self._get_snapshot_recursive_depends(pkg, ignore_pkgs)
-            self._depends_cache[cache_key] = set(dependencies)
-            return dependencies
 
         # if pkg comes from additional_packages_snapshot, extract from its package.xml
         if (

--- a/vinca/test_distro_dependencies.py
+++ b/vinca/test_distro_dependencies.py
@@ -14,6 +14,7 @@ def test_dependency_walk_reuses_direct_dependencies_across_roots():
     distro = Distro.__new__(Distro)
     distro._depends_cache = {}
     distro._direct_depends_cache = {}
+    distro.snapshot = None
     distro.additional_packages_snapshot = None
     distro.check_package = lambda name: name in graph
     distro._walker = Mock()
@@ -41,6 +42,7 @@ def test_dependency_walk_honors_ignored_packages():
     distro = Distro.__new__(Distro)
     distro._depends_cache = {}
     distro._direct_depends_cache = {}
+    distro.snapshot = None
     distro.additional_packages_snapshot = None
     distro.check_package = lambda name: name in graph
     distro._walker = Mock()
@@ -58,6 +60,7 @@ def test_dependency_walk_excludes_root_in_cycles():
     distro = Distro.__new__(Distro)
     distro._depends_cache = {}
     distro._direct_depends_cache = {}
+    distro.snapshot = None
     distro.additional_packages_snapshot = None
     distro.check_package = lambda name: name in graph
     distro._get_direct_depends = lambda name: graph[name]
@@ -69,6 +72,7 @@ def test_dependency_walk_excludes_root_from_self_dependency():
     distro = Distro.__new__(Distro)
     distro._depends_cache = {}
     distro._direct_depends_cache = {}
+    distro.snapshot = None
     distro.additional_packages_snapshot = None
     distro.check_package = lambda name: name == "a"
     distro._get_direct_depends = lambda name: {"a"}
@@ -81,6 +85,7 @@ def test_dependency_walk_excludes_root_from_longer_cycle():
     distro = Distro.__new__(Distro)
     distro._depends_cache = {}
     distro._direct_depends_cache = {}
+    distro.snapshot = None
     distro.additional_packages_snapshot = None
     distro.check_package = lambda name: name in graph
     distro._get_direct_depends = lambda name: graph[name]

--- a/vinca/test_snapshot_metadata.py
+++ b/vinca/test_snapshot_metadata.py
@@ -49,6 +49,7 @@ def make_snapshot_distro(monkeypatch):
     distro._distribution_type = "ros2"
     distro._additional_xml_cache = {}
     distro._depends_cache = {}
+    distro._direct_depends_cache = {}
     distro._distro = Mock()
     distro._distro.get_release_package_xml.return_value = LIVE_PACKAGE_XML
     distro._walker = Mock()
@@ -145,11 +146,16 @@ def test_empty_snapshot_keeps_live_rosdistro_behavior():
     distro.additional_packages_snapshot = None
     distro.build_packages = set()
     distro._depends_cache = {}
+    distro._direct_depends_cache = {}
     distro._distro = Mock()
     distro._distro.release_packages = {"live_package": Mock()}
     distro._distro.get_release_package_xml.return_value = LIVE_PACKAGE_XML
     distro._walker = Mock()
-    distro._walker.get_recursive_depends.return_value = {"live_dependency"}
+    distro._walker.get_depends.side_effect = (
+        lambda package, dependency_type, ros_packages_only: (
+            {"live_dependency"} if dependency_type == "run" else set()
+        )
+    )
 
     assert distro.check_package("live_package")
     assert distro.get_release_package_xml("live_package") == LIVE_PACKAGE_XML


### PR DESCRIPTION
CI is red on `master` right now — all three `test` jobs fail on e10a578, so every open PR is red through no fault of its own.

`pixi run lint-check` is what fails:

```
F821 Undefined name `ignore_pkgs`  --> vinca/distro.py:186
F821 Undefined name `cache_key`    --> vinca/distro.py:187
```

#134 added a snapshot shortcut to `_get_direct_depends`, but the block reads `ignore_pkgs` and `cache_key`, and neither exists in that scope. They're locals of `get_depends`, which is where the block was clearly written for: it computes a full recursive closure via `_get_snapshot_recursive_depends` and stores it under `self._depends_cache[cache_key]`, the recursive cache. `_get_direct_depends` returns direct dependencies and caches them per package in `_direct_depends_cache`.

So this isn't only a lint problem. Any snapshot-based distro would hit `NameError` as soon as it resolved a dependency, and ros-rolling runs with a snapshot. Moving the block into `get_depends` puts it back where its variables live and where the semantics match.

There were also 4 failing tests, all fixture problems that the lint failure was masking:

- `test_distro_dependencies.py` builds `Distro` through `Distro.__new__` and never sets `snapshot`, so the walk raised `AttributeError` as soon as it reached the snapshot check.
- `make_snapshot_distro` and `test_empty_snapshot_keeps_live_rosdistro_behavior` set `_depends_cache` but not `_direct_depends_cache`.
- `test_empty_snapshot_keeps_live_rosdistro_behavior` stubbed `_walker.get_recursive_depends`, but `_get_direct_depends` calls `_walker.get_depends` once per dependency type. The stub was never reached, so the mock leaked through as `TypeError: 'Mock' object is not iterable`. It now stubs the method the code actually calls, matching how `test_distro_dependencies.py` does it.

## Testing

`pixi run test` goes from 4 failed / 146 passed to 150 passed, and `pixi run lint-check` passes.

I have not run the generator against a real snapshot distro, so I have not confirmed end to end that the snapshot dependency resolution produces the right packages — only that it no longer blows up and that the tests from #134 pass. Someone closer to that feature should sanity-check the intent, since I fixed this from the outside; it's possible the shortcut was meant to be a direct-dependency lookup feeding the existing walk instead, which would be a bigger change.
