### PR TITLE
Do not re-download package.xml if the package matches the used one in rosdistro

### DIFF
--- a/vinca/distro.py
+++ b/vinca/distro.py
@@ -349,15 +349,42 @@ class Distro(object):
         repo = self._distro.repositories[pkg.repository_name].release_repository
         return repo.version.split("-")[0]
 
+    def live_cache_matches_snapshot(self, pkg_name, snapshot_entry):
+        """Return whether rosdistro's cached manifest is the pinned snapshot source.
+
+        A snapshot pins the release repository URL, the package-specific release
+        tag, and the release version.  Only an exact match may reuse rosdistro's
+        local ``DistributionCache``; otherwise the manifest must be read from the
+        immutable snapshot source.
+        """
+
+        for live_name in (pkg_name, pkg_name.replace("_", "-")):
+            try:
+                package = self._distro.release_packages[live_name]
+                repository = self._distro.repositories[package.repository_name]
+                release_repository = repository.release_repository
+                return (
+                    release_repository.url == snapshot_entry.get("url")
+                    and get_release_tag(release_repository, live_name)
+                    == snapshot_entry.get("tag")
+                    and release_repository.version.split("-")[0]
+                    == snapshot_entry.get("version")
+                )
+            except (AttributeError, KeyError, TypeError):
+                continue
+        return False
+
     def get_release_package_xml(self, pkg_name):
+        pkg_info = self._get_snapshot_package_info(pkg_name)
         if (
-            self.additional_packages_snapshot
+            pkg_info is None
+            and self.additional_packages_snapshot
             and pkg_name in self.additional_packages_snapshot
         ):
             pkg_info = self.additional_packages_snapshot[pkg_name]
-            return self.get_package_xml_for_additional_package(pkg_info)
-        pkg_info = self._get_snapshot_package_info(pkg_name)
         if pkg_info is not None:
+            if self.live_cache_matches_snapshot(pkg_name, pkg_info):
+                return self._distro.get_release_package_xml(pkg_name)
             return self.get_package_xml_for_additional_package(pkg_info)
         return self._distro.get_release_package_xml(pkg_name)
 

--- a/vinca/test_snapshot_metadata.py
+++ b/vinca/test_snapshot_metadata.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import vinca.main as main
 from vinca.distro import Distro
@@ -89,6 +89,54 @@ def test_snapshot_package_xml_and_dependencies_do_not_follow_live_rosdistro(
     assert distro.get_depends("snapshot_package") == {"snapshot_dependency"}
     distro._distro.get_release_package_xml.assert_not_called()
     distro._walker.get_recursive_depends.assert_not_called()
+
+
+def test_snapshot_package_xml_uses_matching_live_distribution_cache(monkeypatch):
+    distro = make_snapshot_distro(monkeypatch)
+    release_repository = Mock(
+        url="https://github.com/example/snapshot-package-release.git",
+        version="1.0.0-1",
+    )
+    distro._distro.release_packages = {
+        "snapshot_package": Mock(repository_name="snapshot-package")
+    }
+    distro._distro.repositories = {
+        "snapshot-package": Mock(release_repository=release_repository)
+    }
+
+    with patch(
+        "vinca.distro.get_release_tag",
+        return_value="release/rolling/snapshot_package/1.0.0-1",
+    ):
+        package_xml_content = distro.get_release_package_xml("snapshot_package")
+
+    assert package_xml_content == LIVE_PACKAGE_XML
+    distro._distro.get_release_package_xml.assert_called_once_with("snapshot_package")
+
+
+def test_snapshot_package_xml_does_not_use_live_cache_after_snapshot_change(
+    monkeypatch,
+):
+    distro = make_snapshot_distro(monkeypatch)
+    release_repository = Mock(
+        url="https://github.com/example/snapshot-package-release.git",
+        version="2.0.0-1",
+    )
+    distro._distro.release_packages = {
+        "snapshot_package": Mock(repository_name="snapshot-package")
+    }
+    distro._distro.repositories = {
+        "snapshot-package": Mock(release_repository=release_repository)
+    }
+
+    with patch(
+        "vinca.distro.get_release_tag",
+        return_value="release/rolling/snapshot_package/2.0.0-1",
+    ):
+        package_xml_content = distro.get_release_package_xml("snapshot_package")
+
+    assert package_xml_content == SNAPSHOT_PACKAGE_XML
+    distro._distro.get_release_package_xml.assert_not_called()
 
 
 def test_snapshot_metadata_generates_dependency_required_by_pinned_source(


### PR DESCRIPTION
First mitigation for https://github.com/RoboStack/vinca/issues/144 : only donwload the package.xml if the data for the exact same version is not available in the in-memory rosdistro. The full fix for https://github.com/RoboStack/vinca/issues/144 is to add in the snapshot some kind of reference to the snapshotted rosdistro deps data, but for the time being this will keep the speed reasonably fast, especially for recent snapshots.