### PR TITLE
bump: update pixi to the latest version in the build pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Setup Pixi
-      uses: prefix-dev/setup-pixi@v0.10.0
+      uses: prefix-dev/setup-pixi@v0.10.2
       with:
         pixi-version: latest
         cache: true

--- a/vinca/generate_gha.py
+++ b/vinca/generate_gha.py
@@ -402,7 +402,7 @@ def build_win_pipeline(stages, trigger_branch, outfile="win.yml", azure_template
                         # Use the verbose level to get hints why an installation might fail.
                         "log-level": "v",
                         # Use frozen to avoid lockfile satisfiablity issues between the pixi versions used.
-                        "frozen": "true"
+                        "frozen": "true",
                     },
                 },
                 {

--- a/vinca/generate_gha.py
+++ b/vinca/generate_gha.py
@@ -283,7 +283,7 @@ def build_unix_pipeline(
             steps = [
                 {
                     "name": "Checkout code",
-                    "uses": "actions/checkout@v6",
+                    "uses": "actions/checkout@v7",
                 },
                 {
                     "name": f"Build {' '.join([pkg for pkg in batch])}",
@@ -392,12 +392,12 @@ def build_win_pipeline(stages, trigger_branch, outfile="win.yml", azure_template
             }
 
             steps = [
-                {"name": "Checkout code", "uses": "actions/checkout@v6"},
+                {"name": "Checkout code", "uses": "actions/checkout@v7"},
                 {
                     "name": "Setup pixi",
-                    "uses": "prefix-dev/setup-pixi@v0.9.5",
+                    "uses": "prefix-dev/setup-pixi@v0.10.2",
                     "with": {
-                        "pixi-version": "v0.74.0",
+                        "pixi-version": "v0.78.0",
                         "cache": "true",
                     },
                 },

--- a/vinca/generate_gha.py
+++ b/vinca/generate_gha.py
@@ -399,6 +399,7 @@ def build_win_pipeline(stages, trigger_branch, outfile="win.yml", azure_template
                     "with": {
                         "pixi-version": "v0.78.0",
                         "cache": "true",
+                        "log-level": "v",
                     },
                 },
                 {

--- a/vinca/generate_gha.py
+++ b/vinca/generate_gha.py
@@ -399,7 +399,10 @@ def build_win_pipeline(stages, trigger_branch, outfile="win.yml", azure_template
                     "with": {
                         "pixi-version": "v0.78.0",
                         "cache": "true",
+                        # Use the verbose level to get hints why an installation might fail.
                         "log-level": "v",
+                        # Use frozen to avoid lockfile satisfiablity issues between the pixi versions used.
+                        "frozen": "true"
                     },
                 },
                 {


### PR DESCRIPTION
Updating the pixi and action versions for the generated workflows. 

My hunch is that this would solve the issue in https://github.com/RoboStack/ros-jazzy/actions/runs/33612455126/job/100190543296. But im not sure so I also added the `log-level` verbose.