### PR TITLE
feat: Add setup-pixi to unix workflows, and add configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ package_name_mode: both
 
 Once users and downstream projects have migrated, switch to `new` to stop generating the compatibility packages. New ROS 1 package names use the `ros-` prefix; new ROS 2 package names use `ros2-`.
 
+## Configuring setup-pixi in generated workflows
+
+Generated GitHub Actions workflows use `prefix-dev/setup-pixi@v0` by default. Override the action version in `vinca.yaml` when needed:
+
+```yaml
+setup_pixi_version: latest
+pixi_version: latest
+```
+
+`setup_pixi_version` selects the `prefix-dev/setup-pixi` action release and defaults to `v0`. `pixi_version` selects the Pixi binary installed by that action and defaults to `latest`. Semantic versions may be written with or without the `v` prefix; Vinca adds exactly one `v` when needed. Symbolic references such as `latest` and GitHub Action commit hashes are passed through unchanged, so a pinned action is also supported:
+
+```yaml
+setup_pixi_version: 0123456789abcdef0123456789abcdef01234567
+pixi_version: v0.78.0
+```
+
+Pinning a release or full action commit hash is recommended for reproducible workflows.
+
 ## Managing conda-forge pinning
 
 RoboStack repositories can keep their global pins reproducible without copying and

--- a/vinca/config.py
+++ b/vinca/config.py
@@ -2,3 +2,5 @@ selected_platform = None
 ros_distro = None
 skip_testing = None
 parsed_args = None
+setup_pixi_version = None
+pixi_version = None

--- a/vinca/generate_gha.py
+++ b/vinca/generate_gha.py
@@ -7,6 +7,7 @@ import os
 import argparse
 from importlib import resources
 from distutils.dir_util import copy_tree
+from typing import Any
 
 from rich import print
 
@@ -26,6 +27,11 @@ from vinca.main import (
     get_conda_subdir,
 )
 from vinca import config
+
+
+# Use the v0 version of setup-pixi by default, which should give you the last major release
+DEFAULT_SETUP_PIXI_VERSION = "v0"
+DEFAULT_PIXI_VERSION = "latest"
 
 
 def read_azure_script(fn):
@@ -230,11 +236,22 @@ def add_additional_recipes(args):
 #       - '*.yaml'
 
 
+MAX_WORKFLOW_SIZE_BYTES = 500 * 1024
+
+
 def dump_for_gha(doc, f):
     s = yaml.dump(doc, sort_keys=False, Dumper=NoAliasDumper)
     s = s.replace("'on':", "on:")
     with open(f, "w") as fo:
         fo.write(s)
+
+    workflow_size = os.path.getsize(f)
+    if workflow_size > MAX_WORKFLOW_SIZE_BYTES:
+        raise RuntimeError(
+            f"Generated workflow {f} is {workflow_size / 1024:.1f} KiB, exceeding "
+            f"the {MAX_WORKFLOW_SIZE_BYTES / 1024:.0f} KiB limit. Increase "
+            "--batch_size to reduce the number of generated jobs."
+        )
 
 
 def get_stage_name(batch):
@@ -248,6 +265,39 @@ def get_stage_name(batch):
     return " ".join(stage_name)
 
 
+def normalize_version(version: str) -> str:
+    """Normalize a release while leaving action refs such as commit SHAs intact."""
+    version = str(version).strip()
+    if not version:
+        raise ValueError("Version values must not be empty")
+
+    # Full GitHub Action commit hashes and symbolic refs such as ``latest`` must
+    # be passed through verbatim. Only a bare semantic version gets a v prefix.
+    if re.fullmatch(r"[0-9a-fA-F]{40}", version):
+        return version
+    if re.fullmatch(r"v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", version):
+        return version
+    if re.fullmatch(r"\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", version):
+        return f"v{version}"
+    return version
+
+
+def get_setup_pixi_step(
+    setup_pixi_version: str = DEFAULT_SETUP_PIXI_VERSION,
+    pixi_version: str = DEFAULT_PIXI_VERSION,
+) -> dict[str, Any]:
+    return {
+        "name": "Setup pixi",
+        "uses": f"prefix-dev/setup-pixi@{normalize_version(setup_pixi_version)}",
+        "with": {
+            "pixi-version": normalize_version(pixi_version),
+            "cache": "true",
+            "log-level": "v",
+            "frozen": "true",
+        },
+    }
+
+
 def build_unix_pipeline(
     stages,
     trigger_branch,
@@ -257,6 +307,8 @@ def build_unix_pipeline(
     outfile="linux.yml",
     pipeline_name="build_unix",
     target="",
+    setup_pixi_version: str = DEFAULT_SETUP_PIXI_VERSION,
+    pixi_version: str = DEFAULT_PIXI_VERSION,
 ):
     blurb = {"jobs": {}, "name": pipeline_name}
 
@@ -285,6 +337,7 @@ def build_unix_pipeline(
                     "name": "Checkout code",
                     "uses": "actions/checkout@v7",
                 },
+                get_setup_pixi_step(setup_pixi_version, pixi_version),
                 {
                     "name": f"Build {' '.join([pkg for pkg in batch])}",
                     "env": build_env,
@@ -325,6 +378,8 @@ def build_linux_pipeline(
     runs_on="ubuntu-latest",
     outfile="linux.yml",
     pipeline_name="build_linux",
+    setup_pixi_version: str = DEFAULT_SETUP_PIXI_VERSION,
+    pixi_version: str = DEFAULT_PIXI_VERSION,
 ):
     build_unix_pipeline(
         stages,
@@ -335,6 +390,8 @@ def build_linux_pipeline(
         outfile=outfile,
         pipeline_name=pipeline_name,
         target="linux-64",
+        setup_pixi_version=setup_pixi_version,
+        pixi_version=pixi_version,
     )
 
 
@@ -347,6 +404,8 @@ def build_osx_pipeline(
     script=azure_unix_script,
     target="osx-64",
     pipeline_name="build_osx64",
+    setup_pixi_version: str = DEFAULT_SETUP_PIXI_VERSION,
+    pixi_version: str = DEFAULT_PIXI_VERSION,
 ):
     build_unix_pipeline(
         stages,
@@ -357,10 +416,19 @@ def build_osx_pipeline(
         outfile=outfile,
         target=target,
         pipeline_name=pipeline_name,
+        setup_pixi_version=setup_pixi_version,
+        pixi_version=pixi_version,
     )
 
 
-def build_win_pipeline(stages, trigger_branch, outfile="win.yml", azure_template=None):
+def build_win_pipeline(
+    stages,
+    trigger_branch,
+    outfile="win.yml",
+    azure_template=None,
+    setup_pixi_version: str = DEFAULT_SETUP_PIXI_VERSION,
+    pixi_version: str = DEFAULT_PIXI_VERSION,
+):
     vm_imagename = "windows-2022"
     # Build Win pipeline
     blurb = {"jobs": {}, "name": "build_win"}
@@ -393,18 +461,7 @@ def build_win_pipeline(stages, trigger_branch, outfile="win.yml", azure_template
 
             steps = [
                 {"name": "Checkout code", "uses": "actions/checkout@v7"},
-                {
-                    "name": "Setup pixi",
-                    "uses": "prefix-dev/setup-pixi@v0.10.2",
-                    "with": {
-                        "pixi-version": "v0.78.0",
-                        "cache": "true",
-                        # Use the verbose level to get hints why an installation might fail.
-                        "log-level": "v",
-                        # Use frozen to avoid lockfile satisfiablity issues between the pixi versions used.
-                        "frozen": "true",
-                    },
-                },
+                get_setup_pixi_step(setup_pixi_version, pixi_version),
                 {
                     "uses": "egor-tensin/cleanup-path@v5",
                     "with": {
@@ -482,6 +539,8 @@ def main():
     args = parse_command_line(sys.argv)
 
     full_tree = get_full_tree()
+    setup_pixi_version = config.setup_pixi_version or DEFAULT_SETUP_PIXI_VERSION
+    pixi_version = config.pixi_version or DEFAULT_PIXI_VERSION
 
     metas = []
 
@@ -583,12 +642,16 @@ def main():
             args.trigger_branch,
             outfile="linux.yml",
             pipeline_name="build_linux64",
+            setup_pixi_version=setup_pixi_version,
+            pixi_version=pixi_version,
         )
 
     if args.platform == "osx-64":
         build_osx_pipeline(
             stages,
             args.trigger_branch,
+            setup_pixi_version=setup_pixi_version,
+            pixi_version=pixi_version,
         )
 
     if args.platform == "osx-arm64":
@@ -600,6 +663,8 @@ def main():
             script=azure_unix_script,
             target=platform,
             pipeline_name="build_osx_arm64",
+            setup_pixi_version=setup_pixi_version,
+            pixi_version=pixi_version,
         )
 
     if args.platform == "linux-aarch64":
@@ -611,11 +676,19 @@ def main():
             outfile="linux_aarch64.yml",
             target=platform,
             pipeline_name="build_linux_aarch64",
+            setup_pixi_version=setup_pixi_version,
+            pixi_version=pixi_version,
         )
 
     # windows
     if args.platform == "win-64":
-        build_win_pipeline(stages, args.trigger_branch, outfile="win.yml")
+        build_win_pipeline(
+            stages,
+            args.trigger_branch,
+            outfile="win.yml",
+            setup_pixi_version=setup_pixi_version,
+            pixi_version=pixi_version,
+        )
 
     if args.platform == "emscripten-wasm32":
         build_unix_pipeline(
@@ -624,4 +697,6 @@ def main():
             outfile="emscripten_wasm32.yml",
             pipeline_name="build_emscripten_wasm32",
             target="emscripten-wasm32",
+            setup_pixi_version=setup_pixi_version,
+            pixi_version=pixi_version,
         )

--- a/vinca/main.py
+++ b/vinca/main.py
@@ -239,6 +239,8 @@ def read_vinca_yaml(filepath):
 
     config.ros_distro = vinca_conf["ros_distro"]
     config.skip_testing = vinca_conf.get("skip_testing", True)
+    config.setup_pixi_version = vinca_conf.get("setup_pixi_version")
+    config.pixi_version = vinca_conf.get("pixi_version")
 
     vinca_conf["_conda_indexes"] = get_conda_index(
         vinca_conf, os.path.dirname(filepath)

--- a/vinca/test_generate_gha.py
+++ b/vinca/test_generate_gha.py
@@ -3,7 +3,11 @@
 import pytest
 
 from vinca import config
-from vinca.generate_gha import get_stage_name
+from vinca.generate_gha import (
+    build_unix_pipeline,
+    get_setup_pixi_step,
+    get_stage_name,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -32,3 +36,61 @@ def test_get_stage_name_strips_only_the_legacy_prefix(package, expected):
 def test_get_stage_name_joins_a_batch():
     batch = ["ros-rolling-rclcpp", "ros2-ament-package"]
     assert get_stage_name(batch) == "rclcpp ros2-ament-package"
+
+
+def test_unix_pipeline_sets_up_pixi(tmp_path):
+    outfile = tmp_path / "linux.yml"
+
+    build_unix_pipeline(
+        [[["ros-rolling-rclcpp"]]],
+        "buildbranch_linux",
+        script="build command",
+        outfile=outfile,
+        target="linux-64",
+    )
+
+    workflow = pytest.importorskip("yaml").safe_load(outfile.read_text())
+    setup_step = workflow["jobs"]["stage_0_job_0"]["steps"][1]
+    assert setup_step == {
+        "name": "Setup pixi",
+        "uses": "prefix-dev/setup-pixi@v0",
+        "with": {
+            "pixi-version": "latest",
+            "cache": "true",
+            "log-level": "v",
+            "frozen": "true",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "configured_version,expected_ref",
+    [
+        ("latest", "latest"),
+        ("0.10.2", "v0.10.2"),
+        ("v0.10.2", "v0.10.2"),
+        ("  v0.10.2  ", "v0.10.2"),
+        ("0.10.2-rc.1", "v0.10.2-rc.1"),
+        (
+            "0123456789abcdef0123456789abcdef01234567",
+            "0123456789abcdef0123456789abcdef01234567",
+        ),
+    ],
+)
+def test_setup_pixi_version_can_be_configured(configured_version, expected_ref):
+    step = get_setup_pixi_step(setup_pixi_version=configured_version)
+    assert step["uses"] == f"prefix-dev/setup-pixi@{expected_ref}"
+
+
+@pytest.mark.parametrize(
+    "configured_version,expected_version",
+    [("latest", "latest"), ("0.78.0", "v0.78.0"), ("v0.78.0", "v0.78.0")],
+)
+def test_pixi_version_can_be_configured(configured_version, expected_version):
+    step = get_setup_pixi_step(pixi_version=configured_version)
+    assert step["with"]["pixi-version"] == expected_version
+
+
+def test_setup_pixi_versions_must_not_be_empty():
+    with pytest.raises(ValueError, match="must not be empty"):
+        get_setup_pixi_step(setup_pixi_version="  ")


### PR DESCRIPTION
Introduced `setup_pixi_version` and `pixi_version` for user configuration.
Modified `generate_gha.py` to use default values for setup-pixi and pixi versions.
Use `setup-pixi` in the unix gha workflow files. 