### PR TITLE
fix: populate package repository metadata

### DIFF
--- a/vinca/distro.py
+++ b/vinca/distro.py
@@ -38,6 +38,18 @@ def is_archive_url(url):
     return path.endswith(ARCHIVE_SUFFIXES)
 
 
+def is_bloom_release_repository_url(url):
+    """Return True when url names a Bloom-generated release repository."""
+    path = urllib.parse.urlparse(url).path.rstrip("/")
+    repository_name = posixpath.basename(path).removesuffix(".git").lower()
+    return repository_name.endswith(("-release", "_release"))
+
+
+def _strip_git_suffix(url):
+    """Return a repository URL without its optional ``.git`` suffix."""
+    return url[:-4] if url.lower().endswith(".git") else url
+
+
 def _normalize_member(name):
     """Return an archive member name without its './' prefix and trailing slash."""
     name = name.strip("/")
@@ -313,6 +325,38 @@ class Distro(object):
         repo = self._distro.repositories[pkg.repository_name].release_repository
         release_tag = get_release_tag(repo, pkg_name)
         return repo.url, release_tag, "tag"
+
+    def get_repository_url(self, pkg_name, package_urls=()):
+        """Return the best declared upstream repository for a package."""
+        pkg_info = self._get_snapshot_package_info(pkg_name)
+        if pkg_info is not None:
+            if repository := pkg_info.get("repository"):
+                return _strip_git_suffix(repository)
+
+        additional_info = (self.additional_packages_snapshot or {}).get(pkg_name)
+        if additional_info is not None:
+            if repository := additional_info.get("repository"):
+                return _strip_git_suffix(repository)
+        else:
+            package = self._distro.release_packages.get(pkg_name)
+            if package is not None:
+                repository = self._distro.repositories[package.repository_name]
+                source_repository = repository.source_repository
+                if (
+                    source_repository is not None
+                    and source_repository.url
+                    and not is_bloom_release_repository_url(source_repository.url)
+                ):
+                    return _strip_git_suffix(source_repository.url)
+
+        for package_url in package_urls:
+            if (
+                package_url.type == "repository"
+                and package_url.url
+                and not is_bloom_release_repository_url(package_url.url)
+            ):
+                return _strip_git_suffix(package_url.url)
+        return None
 
     def check_package(self, pkg_name):
         # If the package is in the additional_packages_snapshot, it is always considered valid

--- a/vinca/main.py
+++ b/vinca/main.py
@@ -479,14 +479,12 @@ def parse_package(pkg, distro, vinca_conf, path):
         recipe["about"]["maintainers"].append(name)
 
     for u in pkg["urls"]:
-        # if u.type == 'repository' :
-        #     recipe['source']['git'] = u.url
-        #     recipe['source']['tag'] = recipe['package']['version']
         if u.type == "website":
             recipe["about"]["homepage"] = u.url
 
-        # if u.type == 'bugtracker' :
-        #    recipe['about']['url_issues'] = u.url
+    repository = distro.get_repository_url(pkg.name, pkg["urls"])
+    if repository:
+        recipe["about"]["repository"] = repository
 
     if not recipe["source"].get("git", None):
         aux = path.split("/")

--- a/vinca/recipes.py
+++ b/vinca/recipes.py
@@ -286,14 +286,17 @@ def _requirement_sort_key(requirement):
     )
 
 
-def _add_metadata(output: dict[str, Any], package: Any, shortname: str) -> None:
-    """Populate ``about`` from the package.xml URLs, license and description."""
+def _add_metadata(
+    output: dict[str, Any], package: Any, shortname: str, distro: Distro
+) -> None:
+    """Populate ``about`` from package.xml and rosdistro metadata."""
     about = output["about"] = {}
     for url in package.urls:
         if url.type == "website":
             about["homepage"] = url.url
-        elif url.type == "repository":
-            about["repository"] = url.url
+    repository = distro.get_repository_url(shortname, package.urls)
+    if repository:
+        about["repository"] = repository
     if package.licenses:
         license_expression = convert_to_spdx_license(
             [str(license) for license in package.licenses], package_name=shortname
@@ -459,5 +462,5 @@ def generate_output(
     _adjust_requirements(output["requirements"], package_prefix)
     if dependencies_only:
         return output["requirements"]
-    _add_metadata(output, package, shortname)
+    _add_metadata(output, package, shortname, distro)
     return output

--- a/vinca/snapshot.py
+++ b/vinca/snapshot.py
@@ -79,6 +79,8 @@ def main():
             continue
 
         output[dep] = {"url": url, "version": version, "tag": tag}
+        if repository := distro.get_repository_url(dep):
+            output[dep]["repository"] = repository
 
         if not args.quiet:
             print("{0:{2}} {1}".format(dep, version, max_len + 2))

--- a/vinca/test_recipes.py
+++ b/vinca/test_recipes.py
@@ -40,12 +40,21 @@ def package_xml(name, build_type="ament_cmake", depends=()):
 class FakeDistro:
     name = "rolling"
 
-    def __init__(self, xml_by_name, ros1=False):
+    def __init__(self, xml_by_name, ros1=False, repository_by_name=None):
         self._xml_by_name = xml_by_name
         self._ros1 = ros1
+        self._repository_by_name = repository_by_name or {}
 
     def get_release_package_xml(self, name):
         return self._xml_by_name.get(name)
+
+    def get_repository_url(self, name, package_urls=()):
+        if repository := self._repository_by_name.get(name):
+            return repository.removesuffix(".git")
+        for package_url in package_urls:
+            if package_url.type == "repository":
+                return package_url.url.removesuffix(".git")
+        return None
 
     def check_ros1(self):
         return self._ros1
@@ -90,7 +99,10 @@ def build(
     dependencies_only=False,
     **overrides,
 ):
-    distro = FakeDistro({name: package_xml(name, build_type, depends)})
+    distro = FakeDistro(
+        {name: package_xml(name, build_type, depends)},
+        repository_by_name={name: f"https://github.com/ros2/{name}.git"},
+    )
     return generate_output(
         name,
         make_config(name, **overrides),
@@ -154,11 +166,30 @@ def test_generate_output_produces_a_complete_recipe():
         },
         "about": {
             "homepage": "https://example.org/demo",
-            "repository": "https://github.com/example/demo",
+            "repository": "https://github.com/ros2/demo",
             "license": "Apache-2.0",
             "summary": "Description of demo.",
         },
     }
+
+
+def test_generate_output_uses_rosdistro_repository_instead_of_manifest_url():
+    distro = FakeDistro(
+        {"demo": package_xml("demo")},
+        repository_by_name={"demo": "https://github.com/ros2/demo.git"},
+    )
+
+    output = generate_output("demo", make_config("demo"), distro, "1.2.3")
+
+    assert output["about"]["repository"] == "https://github.com/ros2/demo"
+
+
+def test_generate_output_uses_manifest_repository_as_fallback():
+    distro = FakeDistro({"demo": package_xml("demo")})
+
+    output = generate_output("demo", make_config("demo"), distro, "1.2.3")
+
+    assert output["about"]["repository"] == "https://github.com/example/demo"
 
 
 def test_cmake_is_build_only_on_emscripten():

--- a/vinca/test_snapshot_metadata.py
+++ b/vinca/test_snapshot_metadata.py
@@ -33,11 +33,13 @@ def make_snapshot_distro(monkeypatch):
     snapshot = {
         "snapshot_package": {
             "url": "https://github.com/example/snapshot-package-release.git",
+            "repository": "https://github.com/example/snapshot-package.git",
             "version": "1.0.0",
             "tag": "release/rolling/snapshot_package/1.0.0-1",
         },
         "snapshot_dependency": {
             "url": "https://github.com/example/snapshot-dependency-release.git",
+            "repository": "https://github.com/example/snapshot-dependency.git",
             "version": "1.0.0",
             "tag": "release/rolling/snapshot_dependency/1.0.0-1",
         },
@@ -82,6 +84,10 @@ def test_snapshot_package_xml_and_dependencies_do_not_follow_live_rosdistro(
         "https://github.com/example/snapshot-package-release.git",
         "release/rolling/snapshot_package/1.0.0-1",
         "tag",
+    )
+    assert (
+        distro.get_repository_url("snapshot_package")
+        == "https://github.com/example/snapshot-package"
     )
     assert distro.get_version("snapshot_package") == "1.0.0"
     assert "<version>1.0.0</version>" in package_xml_content
@@ -173,6 +179,9 @@ def test_snapshot_metadata_generates_dependency_required_by_pinned_source(
         "name": "ros2-snapshot-package",
         "version": "1.0.0",
     }
+    assert output["about"]["repository"] == (
+        "https://github.com/example/snapshot-package"
+    )
     assert "ros2-snapshot-dependency" in output["requirements"]["host"]
     assert "ros2-live-dependency" not in output["requirements"]["host"]
 
@@ -187,6 +196,90 @@ def test_snapshot_is_authoritative_for_package_membership(monkeypatch):
         "snapshot_package",
         "snapshot_dependency",
     }
+
+
+def test_live_repository_url_requires_upstream_source_metadata():
+    distro = Distro.__new__(Distro)
+    distro.snapshot = None
+    distro.additional_packages_snapshot = None
+    distro._distro = Mock()
+    distro._distro.release_packages = {
+        "source_package": Mock(repository_name="source-package"),
+        "release_only_package": Mock(repository_name="release-only-package"),
+        "bloom_source_package": Mock(repository_name="bloom-source-package"),
+    }
+    distro._distro.repositories = {
+        "source-package": Mock(
+            source_repository=Mock(url="https://github.com/example/source.git"),
+            release_repository=Mock(
+                url="https://github.com/example/source-release.git"
+            ),
+        ),
+        "release-only-package": Mock(
+            source_repository=None,
+            release_repository=Mock(
+                url="https://github.com/example/release-only-release.git"
+            ),
+        ),
+        "bloom-source-package": Mock(
+            source_repository=Mock(
+                url="https://github.com/example/bloom-source-release.git"
+            ),
+            release_repository=Mock(
+                url="https://github.com/ros2-gbp/bloom-source-release.git"
+            ),
+        ),
+    }
+
+    assert (
+        distro.get_repository_url("source_package")
+        == "https://github.com/example/source"
+    )
+    assert distro.get_repository_url("release_only_package") is None
+    assert (
+        distro.get_repository_url(
+            "release_only_package",
+            [Mock(type="repository", url="https://github.com/example/upstream.git")],
+        )
+        == "https://github.com/example/upstream"
+    )
+    assert distro.get_repository_url("bloom_source_package") is None
+
+
+def test_additional_package_repository_must_be_explicit():
+    distro = Distro.__new__(Distro)
+    distro.snapshot = None
+    distro.additional_packages_snapshot = {
+        "explicit": {
+            "url": "https://github.com/example/explicit-release.git",
+            "repository": "https://github.com/example/explicit.git",
+        },
+        "source_only": {"url": "https://github.com/example/source-only.git"},
+    }
+
+    assert (
+        distro.get_repository_url("explicit") == "https://github.com/example/explicit"
+    )
+    assert distro.get_repository_url("source_only") is None
+    assert (
+        distro.get_repository_url(
+            "source_only",
+            [Mock(type="repository", url="https://github.com/example/source-only.git")],
+        )
+        == "https://github.com/example/source-only"
+    )
+    assert (
+        distro.get_repository_url(
+            "source_only",
+            [
+                Mock(
+                    type="repository",
+                    url="https://github.com/example/source-only-release.git",
+                )
+            ],
+        )
+        is None
+    )
 
 
 def test_empty_snapshot_keeps_live_rosdistro_behavior():


### PR DESCRIPTION
`about.repository` is often missing from generated ROS recipes. This selects it in this order:

1. a snapshot or additional recipe's explicit `repository`
2. rosdistro's `source_repository`, unless it is a Bloom release repository
3. the package manifest's `<url type="repository">` value

Repository URLs are stored without the `.git` suffix. Source-download URLs and Bloom release repositories are not treated as upstream identity. Snapshots preserve the selected URL. Homepage, license, and summary metadata continue to come from the package manifest.

## Audit

Generating all 1,551 Linux recipes from `RoboStack/ros-rolling` produced 557 changes:

- 462 additions, all from rosdistro source repository entries
- 95 replacements: 45 URL spelling changes and 50 material repository changes
- no removals

The baseline contained 220 manifest repository URLs. The fallback keeps them when rosdistro has no usable source repository, including these reviewed cases:

- Rolling still declares MoveIt as `ros-planning/moveit2`. GitHub redirects that path to the canonical `moveit/moveit2` repository. Consumers should resolve GitHub redirects and use the API's `full_name` rather than deriving an owner and name from the URL text.
- Rolling declares MAVLink's source as `mavlink/mavlink-gbp-release`. That Bloom repository is rejected, so the manifest's `mavlink/mavlink` repository is retained.

<details>
<summary>Full <code>about.repository</code> comparison</summary>

```yaml
rolling_linux_64:
  generated: 1551
  changes:
    total: 557
    added: 462
    replaced: 95
    removed: 0
  added:
    - repository: https://git.libcamera.org/libcamera/libcamera
      recipes:
        - ros2-libcamera
    - repository: https://github.com/ajtudela/laser_segmentation
      recipes:
        - ros2-laser-segmentation
    - repository: https://github.com/ajtudela/slg_msgs
      recipes:
        - ros2-slg-msgs
    - repository: https://github.com/ament/ament_cmake
      recipes:
        - ros2-ament-cmake
        - ros2-ament-cmake-auto
        - ros2-ament-cmake-core
        - ros2-ament-cmake-export-definitions
        - ros2-ament-cmake-export-dependencies
        - ros2-ament-cmake-export-include-directories
        - ros2-ament-cmake-export-libraries
        - ros2-ament-cmake-export-link-flags
        - ros2-ament-cmake-export-targets
        - ros2-ament-cmake-gen-version-h
        - ros2-ament-cmake-gmock
        - ros2-ament-cmake-google-benchmark
        - ros2-ament-cmake-gtest
        - ros2-ament-cmake-include-directories
        - ros2-ament-cmake-libraries
        - ros2-ament-cmake-pytest
        - ros2-ament-cmake-python
        - ros2-ament-cmake-target-dependencies
        - ros2-ament-cmake-test
        - ros2-ament-cmake-vendor-package
        - ros2-ament-cmake-version
    - repository: https://github.com/ament/ament_index
      recipes:
        - ros2-ament-index-cpp
        - ros2-ament-index-python
    - repository: https://github.com/ament/ament_lint
      recipes:
        - ros2-ament-clang-format
        - ros2-ament-clang-tidy
        - ros2-ament-cmake-clang-format
        - ros2-ament-cmake-clang-tidy
        - ros2-ament-cmake-copyright
        - ros2-ament-cmake-cppcheck
        - ros2-ament-cmake-cpplint
        - ros2-ament-cmake-flake8
        - ros2-ament-cmake-lint-cmake
        - ros2-ament-cmake-mypy
        - ros2-ament-cmake-pep257
        - ros2-ament-cmake-pyflakes
        - ros2-ament-cmake-uncrustify
        - ros2-ament-cmake-xmllint
        - ros2-ament-copyright
        - ros2-ament-cppcheck
        - ros2-ament-cpplint
        - ros2-ament-flake8
        - ros2-ament-lint
        - ros2-ament-lint-auto
        - ros2-ament-lint-cmake
        - ros2-ament-lint-common
        - ros2-ament-mypy
        - ros2-ament-pep257
        - ros2-ament-pycodestyle
        - ros2-ament-pyflakes
        - ros2-ament-uncrustify
        - ros2-ament-xmllint
    - repository: https://github.com/ament/ament_package
      recipes:
        - ros2-ament-package
    - repository: https://github.com/ament/google_benchmark_vendor
      recipes:
        - ros2-google-benchmark-vendor
    - repository: https://github.com/ament/googletest
      recipes:
        - ros2-gtest-vendor
    - repository: https://github.com/ament/uncrustify_vendor
      recipes:
        - ros2-uncrustify-vendor
    - repository: https://github.com/apl-ocean-engineering/marine_msgs
      recipes:
        - ros2-marine-acoustic-msgs
    - repository: https://github.com/AprilRobotics/apriltag
      recipes:
        - ros2-apriltag
    - repository: https://github.com/autowarefoundation/autoware_adapi_msgs
      recipes:
        - ros2-autoware-adapi-v1-msgs
        - ros2-autoware-adapi-version-msgs
    - repository: https://github.com/autowarefoundation/autoware_cmake
      recipes:
        - ros2-autoware-lint-common
    - repository: https://github.com/autowarefoundation/autoware_internal_msgs
      recipes:
        - ros2-autoware-internal-debug-msgs
        - ros2-autoware-internal-metric-msgs
        - ros2-autoware-internal-msgs
        - ros2-autoware-internal-perception-msgs
    - repository: https://github.com/autowarefoundation/autoware_msgs
      recipes:
        - ros2-autoware-common-msgs
        - ros2-autoware-control-msgs
        - ros2-autoware-map-msgs
        - ros2-autoware-perception-msgs
        - ros2-autoware-sensing-msgs
        - ros2-autoware-v2x-msgs
        - ros2-autoware-vehicle-msgs
    - repository: https://github.com/autowarefoundation/ros2_socketcan
      recipes:
        - ros2-ros2-socketcan
        - ros2-ros2-socketcan-msgs
    - repository: https://github.com/BehaviorTree/BehaviorTree.CPP
      recipes:
        - ros2-behaviortree-cpp
    - repository: https://github.com/borglab/gtsam
      recipes:
        - ros2-gtsam
    - repository: https://github.com/botsandus/ament_black
      recipes:
        - ros2-ament-black
        - ros2-ament-cmake-black
    - repository: https://github.com/CCNYRoboticsLab/imu_tools
      recipes:
        - ros2-rviz-imu-plugin
    - repository: https://github.com/christianrauch/apriltag_msgs
      recipes:
        - ros2-apriltag-msgs
    - repository: https://github.com/christianrauch/apriltag_ros
      recipes:
        - ros2-apriltag-ros
    - repository: https://github.com/christianrauch/camera_ros
      recipes:
        - ros2-camera-ros
    - repository: https://github.com/coal-library/coal
      recipes:
        - ros2-coal
    - repository: https://github.com/cra-ros-pkg/robot_localization
      recipes:
        - ros2-robot-localization
    - repository: https://github.com/DLu/tf_transformations
      recipes:
        - ros2-tf-transformations
    - repository: https://github.com/eProsima/foonathan_memory_vendor
      recipes:
        - ros2-foonathan-memory-vendor
    - repository: https://github.com/facontidavide/PlotJuggler
      recipes:
        - ros2-plotjuggler
    - repository: https://github.com/facontidavide/plotjuggler_msgs
      recipes:
        - ros2-plotjuggler-msgs
    - repository: https://github.com/facontidavide/rosx_introspection
      recipes:
        - ros2-rosx-introspection
    - repository: https://github.com/flynneva/udp_msgs
      recipes:
        - ros2-udp-msgs
    - repository: https://github.com/foxglove/foxglove-sdk
      recipes:
        - ros2-foxglove-bridge
        - ros2-foxglove-msgs
    - repository: https://github.com/fujitatomoya/ros2_persist_parameter_server
      recipes:
        - ros2-persist-parameter-server
    - repository: https://github.com/gazebo-release/gz_cmake_vendor
      recipes:
        - ros2-gz-cmake-vendor
    - repository: https://github.com/gazebo-release/gz_common_vendor
      recipes:
        - ros2-gz-common-vendor
    - repository: https://github.com/gazebo-release/gz_dartsim_vendor
      recipes:
        - ros2-gz-dartsim-vendor
    - repository: https://github.com/gazebo-release/gz_fuel_tools_vendor
      recipes:
        - ros2-gz-fuel-tools-vendor
    - repository: https://github.com/gazebo-release/gz_gui_vendor
      recipes:
        - ros2-gz-gui-vendor
    - repository: https://github.com/gazebo-release/gz_math_vendor
      recipes:
        - ros2-gz-math-vendor
    - repository: https://github.com/gazebo-release/gz_msgs_vendor
      recipes:
        - ros2-gz-msgs-vendor
    - repository: https://github.com/gazebo-release/gz_ogre_next_vendor
      recipes:
        - ros2-gz-ogre-next-vendor
    - repository: https://github.com/gazebo-release/gz_physics_vendor
      recipes:
        - ros2-gz-physics-vendor
    - repository: https://github.com/gazebo-release/gz_plugin_vendor
      recipes:
        - ros2-gz-plugin-vendor
    - repository: https://github.com/gazebo-release/gz_rendering_vendor
      recipes:
        - ros2-gz-rendering-vendor
    - repository: https://github.com/gazebo-release/gz_sensors_vendor
      recipes:
        - ros2-gz-sensors-vendor
    - repository: https://github.com/gazebo-release/gz_sim_vendor
      recipes:
        - ros2-gz-sim-vendor
    - repository: https://github.com/gazebo-release/gz_tools_vendor
      recipes:
        - ros2-gz-tools-vendor
    - repository: https://github.com/gazebo-release/gz_transport_vendor
      recipes:
        - ros2-gz-transport-vendor
    - repository: https://github.com/gazebo-release/gz_utils_vendor
      recipes:
        - ros2-gz-utils-vendor
    - repository: https://github.com/gazebo-release/sdformat_vendor
      recipes:
        - ros2-sdformat-vendor
    - repository: https://github.com/gazebosim/ros_gz
      recipes:
        - ros2-ros-gz
        - ros2-ros-gz-bridge
        - ros2-ros-gz-image
        - ros2-ros-gz-interfaces
        - ros2-ros-gz-sim
        - ros2-ros-gz-sim-demos
    - repository: https://github.com/gstavrinos/odom_to_tf_ros2
      recipes:
        - ros2-odom-to-tf-ros2
    - repository: https://github.com/hungpham2511/toppra
      recipes:
        - ros2-toppra
    - repository: https://github.com/jrl-umi3218/jrl-cmakemodules
      recipes:
        - ros2-jrl-cmakemodules
    - repository: https://github.com/KumarRobotics/ublox
      recipes:
        - ros2-ublox
        - ros2-ublox-gps
        - ros2-ublox-msgs
        - ros2-ublox-serialization
    - repository: https://github.com/MetroRobots/polygon_ros
      recipes:
        - ros2-polygon-msgs
    - repository: https://github.com/moveit/osqp_vendor
      recipes:
        - ros2-osqp-vendor
    - repository: https://github.com/Neargye/magic_enum
      recipes:
        - ros2-magic-enum
    - repository: https://github.com/nobleo/rviz_satellite
      recipes:
        - ros2-rviz-satellite
    - repository: https://github.com/octomap/octomap_msgs
      recipes:
        - ros2-octomap-msgs
    - repository: https://github.com/open-rmf/ament_cmake_catch2
      recipes:
        - ros2-ament-cmake-catch2
    - repository: https://github.com/open-rmf/rmf_utils
      recipes:
        - ros2-rmf-utils
    - repository: https://github.com/osrf/osrf_testing_tools_cpp
      recipes:
        - ros2-osrf-testing-tools-cpp
    - repository: https://github.com/ouster-lidar/ouster-ros
      recipes:
        - ros2-ouster-ros
        - ros2-ouster-sensor-msgs
    - repository: https://github.com/pal-robotics/backward_ros
      recipes:
        - ros2-backward-ros
    - repository: https://github.com/pal-robotics/pal_statistics
      recipes:
        - ros2-pal-statistics
        - ros2-pal-statistics-msgs
    - repository: https://github.com/pantor/ruckig
      recipes:
        - ros2-ruckig
    - repository: https://github.com/PickNikRobotics/cpp_polyfills
      recipes:
        - ros2-tcb-span
    - repository: https://github.com/PickNikRobotics/data_tamer
      recipes:
        - ros2-data-tamer-cpp
        - ros2-data-tamer-msgs
    - repository: https://github.com/PickNikRobotics/generate_parameter_library
      recipes:
        - ros2-generate-parameter-library
        - ros2-generate-parameter-library-py
    - repository: https://github.com/PickNikRobotics/launch_param_builder
      recipes:
        - ros2-launch-param-builder
    - repository: https://github.com/PickNikRobotics/RSL
      recipes:
        - ros2-rsl
    - repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins
      recipes:
        - ros2-plotjuggler-ros
    - repository: https://github.com/pradyum/dual_laser_merger
      recipes:
        - ros2-dual-laser-merger
    - repository: https://github.com/RoboSense-LiDAR/rslidar_msg
      recipes:
        - ros2-rslidar-msg
    - repository: https://github.com/RobotWebTools/rosbridge_suite
      recipes:
        - ros2-rosbridge-msgs
    - repository: https://github.com/ros-controls/control_msgs
      recipes:
        - ros2-control-msgs
    - repository: https://github.com/ros-controls/gz_ros2_control
      recipes:
        - ros2-gz-ros2-control
    - repository: https://github.com/ros-controls/ros2_control
      recipes:
        - ros2-controller-interface
        - ros2-controller-manager
        - ros2-controller-manager-msgs
        - ros2-hardware-interface
        - ros2-hardware-interface-testing
        - ros2-ros2-control
        - ros2-ros2-control-test-assets
        - ros2-ros2controlcli
        - ros2-transmission-interface
    - repository: https://github.com/ros-controls/ros2_control_cmake
      recipes:
        - ros2-ros2-control-cmake
    - repository: https://github.com/ros-controls/ros2_controllers
      recipes:
        - ros2-gps-sensor-broadcaster
        - ros2-omni-wheel-drive-controller
    - repository: https://github.com/ros-drivers/ackermann_msgs
      recipes:
        - ros2-ackermann-msgs
    - repository: https://github.com/ros-drivers/joystick_drivers
      recipes:
        - ros2-sdl2-vendor
    - repository: https://github.com/ros-drivers/nmea_msgs
      recipes:
        - ros2-nmea-msgs
    - repository: https://github.com/ros-drivers/nmea_navsat_driver
      recipes:
        - ros2-nmea-navsat-driver
    - repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate
      recipes:
        - ros2-ros-industrial-cmake-boilerplate
    - repository: https://github.com/ros-industrial/stomp
      recipes:
        - ros2-stomp
    - repository: https://github.com/ros-industrial/ur_msgs
      recipes:
        - ros2-ur-msgs
    - repository: https://github.com/ros-misc-utilities/apriltag_detector
      recipes:
        - ros2-apriltag-detector
        - ros2-apriltag-detector-mit
        - ros2-apriltag-detector-umich
        - ros2-apriltag-draw
        - ros2-apriltag-tools
    - repository: https://github.com/ros-misc-utilities/apriltag_mit
      recipes:
        - ros2-apriltag-mit
    - repository: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder
      recipes:
        - ros2-ffmpeg-encoder-decoder
    - repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport
      recipes:
        - ros2-ffmpeg-image-transport
    - repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs
      recipes:
        - ros2-ffmpeg-image-transport-msgs
    - repository: https://github.com/ros-misc-utilities/flex_sync
      recipes:
        - ros2-flex-sync
    - repository: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport
      recipes:
        - ros2-foxglove-compressed-video-transport
    - repository: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation
      recipes:
        - ros2-nav2-minimal-tb3-sim
        - ros2-nav2-minimal-tb4-description
        - ros2-nav2-minimal-tb4-sim
    - repository: https://github.com/ros-perception/image_pipeline
      recipes:
        - ros2-tracetools-image-pipeline
    - repository: https://github.com/ros-perception/image_transport_plugins
      recipes:
        - ros2-compressed-depth-image-transport
        - ros2-compressed-image-transport
        - ros2-image-transport-plugins
        - ros2-theora-image-transport
        - ros2-zstd-image-transport
    - repository: https://github.com/ros-perception/laser_filters
      recipes:
        - ros2-laser-filters
    - repository: https://github.com/ros-perception/laser_geometry
      recipes:
        - ros2-laser-geometry
    - repository: https://github.com/ros-perception/vision_msgs
      recipes:
        - ros2-vision-msgs
    - repository: https://github.com/ros-perception/vision_opencv
      recipes:
        - ros2-image-geometry
    - repository: https://github.com/ros-planning/geometric_shapes
      recipes:
        - ros2-geometric-shapes
    - repository: https://github.com/ros-planning/moveit2
      recipes:
        - ros2-chomp-motion-planner
        - ros2-moveit-configs-utils
        - ros2-moveit-planners-chomp
        - ros2-moveit-plugins
        - ros2-moveit-py
        - ros2-moveit-ros-control-interface
        - ros2-moveit-ros-trajectory-cache
        - ros2-moveit-runtime
        - ros2-moveit-servo
        - ros2-moveit-setup-app-plugins
        - ros2-moveit-setup-controllers
        - ros2-moveit-setup-core-plugins
        - ros2-moveit-setup-framework
        - ros2-moveit-setup-srdf-plugins
    - repository: https://github.com/ros-planning/navigation_msgs
      recipes:
        - ros2-map-msgs
    - repository: https://github.com/ros-planning/py_binding_tools
      recipes:
        - ros2-py-binding-tools
    - repository: https://github.com/ros-planning/random_numbers
      recipes:
        - ros2-random-numbers
    - repository: https://github.com/ros-planning/warehouse_ros
      recipes:
        - ros2-warehouse-ros
    - repository: https://github.com/ros-planning/warehouse_ros_sqlite
      recipes:
        - ros2-warehouse-ros-sqlite
    - repository: https://github.com/ros-teleop/twist_mux
      recipes:
        - ros2-twist-mux
    - repository: https://github.com/ros-teleop/twist_mux_msgs
      recipes:
        - ros2-twist-mux-msgs
    - repository: https://github.com/ros-tooling/graph-monitor
      recipes:
        - ros2-rmw-stats-shim
        - ros2-rosgraph-monitor
        - ros2-rosgraph-monitor-msgs
    - repository: https://github.com/ros-tooling/keyboard_handler
      recipes:
        - ros2-keyboard-handler
    - repository: https://github.com/ros-tooling/libstatistics_collector
      recipes:
        - ros2-libstatistics-collector
    - repository: https://github.com/ros-tooling/topic_tools
      recipes:
        - ros2-topic-tools
        - ros2-topic-tools-interfaces
    - repository: https://github.com/ros-visualization/interactive_markers
      recipes:
        - ros2-interactive-markers
    - repository: https://github.com/ros-visualization/python_qt_binding
      recipes:
        - ros2-python-qt-binding
    - repository: https://github.com/ros/angles
      recipes:
        - ros2-angles
    - repository: https://github.com/ros/class_loader
      recipes:
        - ros2-class-loader
    - repository: https://github.com/ros/diagnostics
      recipes:
        - ros2-diagnostic-aggregator
        - ros2-diagnostic-common-diagnostics
        - ros2-diagnostic-remote-logging
        - ros2-diagnostic-updater
        - ros2-diagnostics
        - ros2-self-test
    - repository: https://github.com/ros/filters
      recipes:
        - ros2-filters
    - repository: https://github.com/ros/pluginlib
      recipes:
        - ros2-ros2plugin
    - repository: https://github.com/ros/robot_state_publisher
      recipes:
        - ros2-robot-state-publisher
    - repository: https://github.com/ros/urdf_launch
      recipes:
        - ros2-urdf-launch
    - repository: https://github.com/ros/urdf_tutorial
      recipes:
        - ros2-urdf-tutorial
    - repository: https://github.com/ros/urdfdom
      recipes:
        - ros2-urdfdom
    - repository: https://github.com/ros/urdfdom_headers
      recipes:
        - ros2-urdfdom-headers
    - repository: https://github.com/ros2-rust/rosidl_rust
      recipes:
        - ros2-rosidl-generator-rs
    - repository: https://github.com/ros2/ament_cmake_ros
      recipes:
        - ros2-ament-cmake-ros
        - ros2-ament-cmake-ros-core
        - ros2-domain-coordinator
        - ros2-rmw-test-fixture
        - ros2-rmw-test-fixture-implementation
    - repository: https://github.com/ros2/common_interfaces
      recipes:
        - ros2-common-interfaces
        - ros2-diagnostic-msgs
        - ros2-geometry-msgs
        - ros2-nav-msgs
        - ros2-sensor-msgs
        - ros2-sensor-msgs-py
        - ros2-shape-msgs
        - ros2-std-msgs
        - ros2-std-srvs
        - ros2-stereo-msgs
        - ros2-trajectory-msgs
        - ros2-visualization-msgs
    - repository: https://github.com/ros2/console_bridge_vendor
      recipes:
        - ros2-console-bridge-vendor
    - repository: https://github.com/ros2/demos
      recipes:
        - ros2-action-tutorials-cpp
        - ros2-action-tutorials-py
        - ros2-composition
        - ros2-demo-nodes-cpp
        - ros2-demo-nodes-cpp-native
        - ros2-demo-nodes-py
        - ros2-dummy-map-server
        - ros2-dummy-robot-bringup
        - ros2-dummy-sensors
        - ros2-image-tools
        - ros2-intra-process-demo
        - ros2-lifecycle
        - ros2-logging-demo
        - ros2-pendulum-control
        - ros2-pendulum-msgs
        - ros2-quality-of-service-demo-cpp
        - ros2-quality-of-service-demo-py
        - ros2-topic-monitor
    - repository: https://github.com/ros2/eigen3_cmake_module
      recipes:
        - ros2-eigen3-cmake-module
    - repository: https://github.com/ros2/example_interfaces
      recipes:
        - ros2-example-interfaces
    - repository: https://github.com/ros2/examples
      recipes:
        - ros2-examples-rclcpp-minimal-action-client
        - ros2-examples-rclcpp-minimal-action-server
        - ros2-examples-rclcpp-minimal-client
        - ros2-examples-rclcpp-minimal-composition
        - ros2-examples-rclcpp-minimal-publisher
        - ros2-examples-rclcpp-minimal-service
        - ros2-examples-rclcpp-minimal-subscriber
        - ros2-examples-rclcpp-minimal-timer
        - ros2-examples-rclcpp-multithreaded-executor
        - ros2-examples-rclpy-executors
        - ros2-examples-rclpy-minimal-action-client
        - ros2-examples-rclpy-minimal-action-server
        - ros2-examples-rclpy-minimal-client
        - ros2-examples-rclpy-minimal-publisher
        - ros2-examples-rclpy-minimal-service
        - ros2-examples-rclpy-minimal-subscriber
    - repository: https://github.com/ros2/geometry2
      recipes:
        - ros2-geometry2
        - ros2-tf2
        - ros2-tf2-bullet
        - ros2-tf2-eigen
        - ros2-tf2-eigen-kdl
        - ros2-tf2-geometry-msgs
        - ros2-tf2-kdl
        - ros2-tf2-msgs
        - ros2-tf2-py
        - ros2-tf2-ros
        - ros2-tf2-ros-py
        - ros2-tf2-sensor-msgs
        - ros2-tf2-tools
    - repository: https://github.com/ros2/launch
      recipes:
        - ros2-launch
        - ros2-launch-pytest
        - ros2-launch-testing
        - ros2-launch-testing-ament-cmake
        - ros2-launch-xml
        - ros2-launch-yaml
    - repository: https://github.com/ros2/launch_ros
      recipes:
        - ros2-launch-ros
        - ros2-launch-testing-ros
        - ros2-ros2launch
    - repository: https://github.com/ros2/libyaml_vendor
      recipes:
        - ros2-libyaml-vendor
    - repository: https://github.com/ros2/message_filters
      recipes:
        - ros2-message-filters
    - repository: https://github.com/ros2/mimick_vendor
      recipes:
        - ros2-mimick-vendor
    - repository: https://github.com/ros2/performance_test_fixture
      recipes:
        - ros2-performance-test-fixture
    - repository: https://github.com/ros2/pybind11_vendor
      recipes:
        - ros2-pybind11-vendor
    - repository: https://github.com/ros2/python_cmake_module
      recipes:
        - ros2-python-cmake-module
    - repository: https://github.com/ros2/rcl
      recipes:
        - ros2-rcl
        - ros2-rcl-action
        - ros2-rcl-lifecycle
        - ros2-rcl-yaml-param-parser
    - repository: https://github.com/ros2/rcl_interfaces
      recipes:
        - ros2-action-msgs
        - ros2-builtin-interfaces
        - ros2-composition-interfaces
        - ros2-lifecycle-msgs
        - ros2-rcl-interfaces
        - ros2-rosgraph-msgs
        - ros2-service-msgs
        - ros2-statistics-msgs
        - ros2-test-msgs
        - ros2-type-description-interfaces
    - repository: https://github.com/ros2/rcl_logging
      recipes:
        - ros2-rcl-logging-implementation
        - ros2-rcl-logging-interface
        - ros2-rcl-logging-noop
        - ros2-rcl-logging-spdlog
    - repository: https://github.com/ros2/rclcpp
      recipes:
        - ros2-rclcpp
        - ros2-rclcpp-action
        - ros2-rclcpp-components
        - ros2-rclcpp-lifecycle
    - repository: https://github.com/ros2/rclpy
      recipes:
        - ros2-rclpy
    - repository: https://github.com/ros2/rcpputils
      recipes:
        - ros2-rcpputils
    - repository: https://github.com/ros2/rcutils
      recipes:
        - ros2-rcutils
    - repository: https://github.com/ros2/realtime_support
      recipes:
        - ros2-rttest
        - ros2-tlsf-cpp
    - repository: https://github.com/ros2/resource_retriever_service
      recipes:
        - ros2-resource-retriever-interfaces
        - ros2-resource-retriever-service-plugin
    - repository: https://github.com/ros2/rmw
      recipes:
        - ros2-rmw
        - ros2-rmw-implementation-cmake
        - ros2-rmw-security-common
    - repository: https://github.com/ros2/rmw_connextdds
      recipes:
        - ros2-rmw-connextdds
        - ros2-rmw-connextdds-common
        - ros2-rti-connext-dds-cmake-module
    - repository: https://github.com/ros2/rmw_cyclonedds
      recipes:
        - ros2-rmw-cyclonedds-cpp
    - repository: https://github.com/ros2/rmw_dds_common
      recipes:
        - ros2-rmw-dds-common
    - repository: https://github.com/ros2/rmw_fastrtps
      recipes:
        - ros2-rmw-fastrtps-cpp
        - ros2-rmw-fastrtps-dynamic-cpp
        - ros2-rmw-fastrtps-shared-cpp
    - repository: https://github.com/ros2/rmw_implementation
      recipes:
        - ros2-rmw-implementation
    - repository: https://github.com/ros2/rmw_zenoh
      recipes:
        - ros2-rmw-zenoh-cpp
        - ros2-zenoh-cpp-vendor
    - repository: https://github.com/ros2/ros_testing
      recipes:
        - ros2-ros-testing
        - ros2-ros2test
    - repository: https://github.com/ros2/ros_workspace
      recipes:
        - ros2-ros-workspace
    - repository: https://github.com/ros2/ros2cli
      recipes:
        - ros2-ros2action
        - ros2-ros2cli
        - ros2-ros2cli-test-interfaces
        - ros2-ros2component
        - ros2-ros2doctor
        - ros2-ros2interface
        - ros2-ros2lifecycle
        - ros2-ros2lifecycle-test-fixtures
        - ros2-ros2multicast
        - ros2-ros2node
        - ros2-ros2param
        - ros2-ros2pkg
        - ros2-ros2run
        - ros2-ros2service
        - ros2-ros2topic
    - repository: https://github.com/ros2/ros2cli_common_extensions
      recipes:
        - ros2-ros2cli-common-extensions
    - repository: https://github.com/ros2/rosbag2
      recipes:
        - ros2-lz4-cmake-module
        - ros2-mcap-vendor
        - ros2-ros2bag
        - ros2-rosbag2
        - ros2-rosbag2-compression
        - ros2-rosbag2-compression-zstd
        - ros2-rosbag2-cpp
        - ros2-rosbag2-interfaces
        - ros2-rosbag2-py
        - ros2-rosbag2-storage
        - ros2-rosbag2-storage-default-plugins
        - ros2-rosbag2-storage-mcap
        - ros2-rosbag2-storage-sqlite3
        - ros2-rosbag2-test-common
        - ros2-rosbag2-test-msgdefs
        - ros2-rosbag2-tests
        - ros2-rosbag2-transport
        - ros2-zstd-cmake-module
    - repository: https://github.com/ros2/rosidl
      recipes:
        - ros2-rosidl-adapter
        - ros2-rosidl-buffer
        - ros2-rosidl-buffer-backend
        - ros2-rosidl-buffer-backend-registry
        - ros2-rosidl-buffer-py
        - ros2-rosidl-cli
        - ros2-rosidl-cmake
        - ros2-rosidl-generator-c
        - ros2-rosidl-generator-cpp
        - ros2-rosidl-generator-type-description
        - ros2-rosidl-parser
        - ros2-rosidl-pycommon
        - ros2-rosidl-runtime-c
        - ros2-rosidl-runtime-cpp
        - ros2-rosidl-typesupport-interface
        - ros2-rosidl-typesupport-introspection-c
        - ros2-rosidl-typesupport-introspection-cpp
    - repository: https://github.com/ros2/rosidl_core
      recipes:
        - ros2-rosidl-core-generators
        - ros2-rosidl-core-runtime
    - repository: https://github.com/ros2/rosidl_defaults
      recipes:
        - ros2-rosidl-default-generators
        - ros2-rosidl-default-runtime
    - repository: https://github.com/ros2/rosidl_dynamic_typesupport
      recipes:
        - ros2-rosidl-dynamic-typesupport
    - repository: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps
      recipes:
        - ros2-rosidl-dynamic-typesupport-fastrtps
    - repository: https://github.com/ros2/rosidl_python
      recipes:
        - ros2-rosidl-generator-py
    - repository: https://github.com/ros2/rosidl_runtime_py
      recipes:
        - ros2-rosidl-runtime-py
    - repository: https://github.com/ros2/rosidl_typesupport
      recipes:
        - ros2-rosidl-typesupport-c
        - ros2-rosidl-typesupport-cpp
    - repository: https://github.com/ros2/rosidl_typesupport_fastrtps
      recipes:
        - ros2-rosidl-typesupport-fastrtps-c
        - ros2-rosidl-typesupport-fastrtps-cpp
    - repository: https://github.com/ros2/rpyutils
      recipes:
        - ros2-rpyutils
    - repository: https://github.com/ros2/rviz
      recipes:
        - ros2-rviz-ogre-vendor
    - repository: https://github.com/ros2/spdlog_vendor
      recipes:
        - ros2-spdlog-vendor
    - repository: https://github.com/ros2/sros2
      recipes:
        - ros2-sros2
        - ros2-sros2-cmake
    - repository: https://github.com/ros2/teleop_twist_joy
      recipes:
        - ros2-teleop-twist-joy
    - repository: https://github.com/ros2/teleop_twist_keyboard
      recipes:
        - ros2-teleop-twist-keyboard
    - repository: https://github.com/ros2/test_interface_files
      recipes:
        - ros2-test-interface-files
    - repository: https://github.com/ros2/tlsf
      recipes:
        - ros2-tlsf
    - repository: https://github.com/ros2/unique_identifier_msgs
      recipes:
        - ros2-unique-identifier-msgs
    - repository: https://github.com/ros2/variants
      recipes:
        - ros2-desktop
        - ros2-desktop-full
        - ros2-perception
        - ros2-ros-base
        - ros2-ros-core
        - ros2-simulation
    - repository: https://github.com/ros2/yaml_cpp_vendor
      recipes:
        - ros2-yaml-cpp-vendor
    - repository: https://github.com/rudislabs/actuator_msgs
      recipes:
        - ros2-actuator-msgs
    - repository: https://github.com/stack-of-tasks/eigenpy
      recipes:
        - ros2-eigenpy
    - repository: https://github.com/stack-of-tasks/pinocchio
      recipes:
        - ros2-pinocchio
    - repository: https://github.com/swri-robotics/marti_common
      recipes:
        - ros2-swri-serial-util
    - repository: https://github.com/swri-robotics/swri_console
      recipes:
        - ros2-swri-console
    - repository: https://github.com/tilk/rtcm_msgs
      recipes:
        - ros2-rtcm-msgs
    - repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver
      recipes:
        - ros2-ur
        - ros2-ur-calibration
        - ros2-ur-moveit-config
    - repository: https://github.com/wg-perception/object_recognition_msgs
      recipes:
        - ros2-object-recognition-msgs
    - repository: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
      recipes:
        - ros2-point-cloud-msg-wrapper
    - repository: https://gitlab.com/boldhearts/ros2_v4l2_camera
      recipes:
        - ros2-v4l2-camera
  replaced:
    - from: https://github.com/ctu-vras/draco_point_cloud_transport
      to: https://github.com/ros-perception/point_cloud_transport_plugins
      recipes:
        - ros2-draco-point-cloud-transport
        - ros2-point-cloud-interfaces
        - ros2-zlib-point-cloud-transport
        - ros2-zstd-point-cloud-transport
    - from: https://github.com/ctu-vras/point_cloud_transport_plugins
      to: https://github.com/ros-perception/point_cloud_transport_plugins
      recipes:
        - ros2-point-cloud-transport-plugins
    - from: https://github.com/davetcoleman/graph_msgs/
      to: https://github.com/PickNikRobotics/graph_msgs
      recipes:
        - ros2-graph-msgs
    - from: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
      to: https://github.com/fzi-forschungszentrum-informatik/lanelet2
      recipes:
        - ros2-lanelet2
        - ros2-lanelet2-core
        - ros2-lanelet2-examples
        - ros2-lanelet2-io
        - ros2-lanelet2-maps
        - ros2-lanelet2-matching
        - ros2-lanelet2-projection
        - ros2-lanelet2-python
        - ros2-lanelet2-routing
        - ros2-lanelet2-traffic-rules
        - ros2-lanelet2-validation
    - from: https://github.com/KIT-MRT/mrt_cmake_modules.git
      to: https://github.com/KIT-MRT/mrt_cmake_modules
      recipes:
        - ros2-mrt-cmake-modules
    - from: https://github.com/mavlink/mavlink.git
      to: https://github.com/mavlink/mavlink
      recipes:
        - ros2-mavlink
    - from: https://github.com/mavlink/mavros.git
      to: https://github.com/mavlink/mavros
      recipes:
        - ros2-libmavconn
        - ros2-mavros
        - ros2-mavros-msgs
    - from: https://github.com/moveit/moveit-resources
      to: https://github.com/ros-planning/moveit2
      recipes:
        - ros2-moveit-resources-prbt-ikfast-manipulator-plugin
        - ros2-moveit-resources-prbt-moveit-config
        - ros2-moveit-resources-prbt-pg70-support
        - ros2-moveit-resources-prbt-support
    - from: https://github.com/moveit/moveit2
      to: https://github.com/ros-planning/moveit2
      recipes:
        - ros2-moveit
        - ros2-moveit-common
        - ros2-moveit-core
        - ros2-moveit-hybrid-planning
        - ros2-moveit-kinematics
        - ros2-moveit-planners
        - ros2-moveit-planners-ompl
        - ros2-moveit-planners-stomp
        - ros2-moveit-ros
        - ros2-moveit-ros-benchmarks
        - ros2-moveit-ros-move-group
        - ros2-moveit-ros-occupancy-map-monitor
        - ros2-moveit-ros-perception
        - ros2-moveit-ros-planning
        - ros2-moveit-ros-planning-interface
        - ros2-moveit-ros-robot-interaction
        - ros2-moveit-ros-visualization
        - ros2-moveit-ros-warehouse
        - ros2-moveit-setup-assistant
        - ros2-moveit-simple-controller-manager
        - ros2-pilz-industrial-motion-planner
        - ros2-pilz-industrial-motion-planner-testutils
    - from: https://github.com/orocos/orocos_kinematics_dynamics
      to: https://github.com/ros2/orocos_kdl_vendor
      recipes:
        - ros2-orocos-kdl-vendor
    - from: https://github.com/ros-controls/control_toolbox/
      to: https://github.com/ros-controls/control_toolbox
      recipes:
        - ros2-control-toolbox
    - from: https://github.com/ros-controls/realtime_tools/
      to: https://github.com/ros-controls/realtime_tools
      recipes:
        - ros2-realtime-tools
    - from: https://github.com/ros-controls/ros2_controllers/
      to: https://github.com/ros-controls/kinematics_interface
      recipes:
        - ros2-kinematics-interface
        - ros2-kinematics-interface-kdl
    - from: https://github.com/ros-controls/ros2_controllers/
      to: https://github.com/ros-controls/ros2_controllers
      recipes:
        - ros2-ackermann-steering-controller
        - ros2-admittance-controller
        - ros2-battery-state-broadcaster
        - ros2-bicycle-steering-controller
        - ros2-chained-filter-controller
        - ros2-diff-drive-controller
        - ros2-force-torque-sensor-broadcaster
        - ros2-forward-command-controller
        - ros2-gpio-controllers
        - ros2-imu-sensor-broadcaster
        - ros2-joint-state-broadcaster
        - ros2-joint-trajectory-controller
        - ros2-magnetometer-broadcaster
        - ros2-mecanum-drive-controller
        - ros2-motion-primitives-controllers
        - ros2-parallel-gripper-controller
        - ros2-pid-controller
        - ros2-pose-broadcaster
        - ros2-range-sensor-broadcaster
        - ros2-ros2-controllers
        - ros2-ros2-controllers-test-nodes
        - ros2-state-interfaces-broadcaster
        - ros2-steering-controllers-library
        - ros2-tricycle-controller
        - ros2-tricycle-steering-controller
    - from: https://github.com/ros-geographic-info/geographic_info.git
      to: https://github.com/ros-geographic-info/geographic_info
      recipes:
        - ros2-geographic-msgs
    - from: https://github.com/ros-perception/perception_pcl
      to: https://github.com/ros-perception/pointcloud_to_laserscan
      recipes:
        - ros2-pointcloud-to-laserscan
    - from: https://github.com/ros-perception/vision_opencv/tree/ros2
      to: https://github.com/ros-perception/vision_opencv
      recipes:
        - ros2-cv-bridge
    - from: https://github.com/ros-planning/moveit_visual_tools/
      to: https://github.com/ros-planning/moveit_visual_tools
      recipes:
        - ros2-moveit-visual-tools
    - from: https://github.com/ros-planning/moveit-resources
      to: https://github.com/ros-planning/moveit_resources
      recipes:
        - ros2-moveit-resources
        - ros2-moveit-resources-fanuc-description
        - ros2-moveit-resources-panda-description
        - ros2-moveit-resources-pr2-description
    - from: https://github.com/ros-simulation/simulation-interfaces
      to: https://github.com/ros-simulation/simulation_interfaces
      recipes:
        - ros2-simulation-interfaces
    - from: https://github.com/ros-visualization/qt_gui_icons
      to: https://github.com/ros-visualization/tango_icons_vendor
      recipes:
        - ros2-tango-icons-vendor
    - from: https://github.com/ros-visualization/rqt_common_plugins
      to: https://github.com/ros-visualization/rqt
      recipes:
        - ros2-rqt-py-common
    - from: https://github.com/ros-visualization/rviz
      to: https://github.com/ros2/rviz
      recipes:
        - ros2-rviz-visual-testing-framework
    - from: https://github.com/ros/robot_model
      to: https://github.com/ros/resource_retriever
      recipes:
        - ros2-resource-retriever
    - from: https://github.com/ros/sdformat_test_files
      to: https://github.com/ros/sdformat_urdf
      recipes:
        - ros2-sdformat-test-files
    - from: https://github.com/ros2/joystick_drivers
      to: https://github.com/ros-drivers/joystick_drivers
      recipes:
        - ros2-joy
    - from: https://github.com/ros2/kdl_parser
      to: https://github.com/ros/kdl_parser
      recipes:
        - ros2-kdl-parser
    - from: https://github.com/swri-robotics/gms_umd
      to: https://github.com/swri-robotics/gps_umd
      recipes:
        - ros2-gps-msgs
  removed: []
```

</details>

## Testing

- `pixi run pytest vinca/test_snapshot_metadata.py vinca/test_recipes.py` (34 passed)
- `pixi run ruff check vinca/distro.py vinca/main.py vinca/recipes.py vinca/test_snapshot_metadata.py vinca/test_recipes.py`
- `pixi run pyrefly check vinca/distro.py vinca/main.py vinca/recipes.py vinca/test_snapshot_metadata.py vinca/test_recipes.py`
- Generated all 1,551 Rolling Linux recipes with `skip_existing` disabled
