### PR TITLE
fix: close if-block before starting a new one in sort_vinca_lists

### DIFF
--- a/vinca/sort_vinca_lists.py
+++ b/vinca/sort_vinca_lists.py
@@ -97,9 +97,21 @@ def sort_vinca_lists(path: Path) -> bool:
 
                 # Start of conditional block: "  - if: ..."
                 if RE_IF_BLOCK.match(line):
-                    if current_if_block is None:
-                        current_if_block = []
-                    current_if_block.append(line)
+                    # If a previous if-block is already open (no blank line or
+                    # comment separated it from this one), close it first.
+                    # Otherwise this new block's "then:" would be treated as a
+                    # continuation of the previous one's, and sorting would
+                    # pool both blocks' items together and redistribute them
+                    # across the block boundary.
+                    if current_if_block is not None and any(
+                        RE_IF_BLOCK.match(bl) for bl in current_if_block
+                    ):
+                        if_blocks.append(current_if_block)
+                        current_if_block = [line]
+                    else:
+                        if current_if_block is None:
+                            current_if_block = []
+                        current_if_block.append(line)
                     i += 1
                     continue
 

--- a/vinca/test_sort_vinca_lists.py
+++ b/vinca/test_sort_vinca_lists.py
@@ -1,0 +1,98 @@
+"""Tests for the vinca.yaml list sorter."""
+
+from vinca.sort_vinca_lists import sort_vinca_lists
+
+BASE = """packages_select_by_deps:
+  - alpha
+  - charlie
+  - bravo
+"""
+
+
+def test_sorts_simple_top_level_items(tmp_path):
+    path = tmp_path / "vinca.yaml"
+    path.write_text(BASE)
+
+    changed = sort_vinca_lists(path)
+
+    assert changed is True
+    items = [
+        line.strip()[2:]
+        for line in path.read_text().splitlines()
+        if line.startswith("  - ")
+    ]
+    assert items == ["alpha", "bravo", "charlie"]
+
+
+def test_leaves_already_sorted_file_unchanged(tmp_path):
+    path = tmp_path / "vinca.yaml"
+    sorted_content = "packages_select_by_deps:\n  - alpha\n  - bravo\n  - charlie\n\n"
+    path.write_text(sorted_content)
+
+    changed = sort_vinca_lists(path)
+
+    assert changed is False
+    assert path.read_text() == sorted_content
+
+
+def test_adjacent_if_blocks_without_separator_stay_isolated(tmp_path):
+    # Regression test: two "- if:" blocks back-to-back with no blank line or
+    # comment between them used to be parsed as a single block, so sorting
+    # pooled both blocks' then-items together and could redistribute an item
+    # from one block's platform condition into the other's.
+    content = """packages_select_by_deps:
+  - if: not wasm32 and not win
+    then:
+      - web_video_server
+      - webots_ros2
+      - yasmin
+      - yasmin_ros
+  - if: linux and not aarch64
+    then:
+      - somepkg
+      - zed_msgs
+
+patch_dir: patch
+"""
+    path = tmp_path / "vinca.yaml"
+    path.write_text(content)
+
+    sort_vinca_lists(path)
+
+    result = path.read_text()
+    first_block, second_block = result.split("- if: not wasm32 and not win")[1].split(
+        "- if: linux and not aarch64"
+    )
+
+    assert "webots_ros2" in first_block
+    assert "yasmin_ros" in first_block
+    assert "webots_ros2" not in second_block
+    assert "somepkg" in second_block
+    assert "zed_msgs" in second_block
+
+
+def test_adjacent_if_blocks_separated_by_comment_stay_isolated(tmp_path):
+    # The comment-separator workaround must keep working alongside the fix.
+    content = """packages_select_by_deps:
+  - if: not wasm32 and not win
+    then:
+      - web_video_server
+      - yasmin
+      - yasmin_ros
+
+  # webots_ros2 is linux-only
+  - if: linux and not aarch64
+    then:
+      - webots_ros2
+      - zed_msgs
+
+patch_dir: patch
+"""
+    path = tmp_path / "vinca.yaml"
+    path.write_text(content)
+
+    sort_vinca_lists(path)
+
+    first_block, second_block = path.read_text().split("- if: linux and not aarch64")
+    assert "- webots_ros2" not in first_block
+    assert "- webots_ros2" in second_block


### PR DESCRIPTION
## Summary
- `vinca-sort-vinca-lists` parses `packages_select_by_deps` (etc.) by collecting all `- if: ... then: [...]` blocks, then sorting each block's `then:` items independently.
- Two `- if:` blocks placed back-to-back, with no blank line or comment between them, were being merged into a single block during parsing: the code only closed the currently-open block when it hit a list-level comment, never when it hit a *new* `- if:` line.
- Once merged, sorting pooled both blocks' `then:` items into one flat list and reassigned them back to their original line positions — which can move an item that belongs to one platform condition into a different, unrelated one.
- Reproduced downstream in `RoboStack/ros-rolling`: adding several packages to a `- if: not wasm32 and not win` block that was immediately followed (no separating comment) by `- if: linux and not aarch64` caused `webots_ros2` (linux-only, non-aarch64) to swap places with an item from the other block after a routine sort. The existing workaround there was a comment between the two blocks, which happened to close the block correctly as a side effect — this PR fixes the actual boundary detection so that workaround isn't required.

## Fix
Close the current if-block whenever a new `- if:` line is seen (mirroring the existing comment-based close), so each block's `then:` items are sorted within their own scope regardless of whether they're adjacent to another block.

## Test plan
- [x] Added `vinca/test_sort_vinca_lists.py` with a regression test reproducing the bug (adjacent if-blocks, no separator) and a companion test confirming the comment-separator workaround still works
- [x] `pixi run test` — 161 passed (was 157; +4 new)
- [x] `pixi run fmt-check` and `pixi run lint-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)