### PR TITLE
fix: reject duplicate if-block conditions within the same list key

### DIFF
--- a/vinca/sort_vinca_lists.py
+++ b/vinca/sort_vinca_lists.py
@@ -5,6 +5,15 @@ Sorts plain `  - item` entries alphabetically within each target list key.
 Conditional blocks (`- if: ... then: [...]`) stay at the end; their inner
 `then:` lists are also sorted.
 
+Also validates that each condition (e.g. "win", "not win", "linux") appears
+in at most one `- if:` block per top-level list key. Two separate blocks for
+the same condition are never wrong on their own, but they're a standing
+foot-gun: a future addition can land in the "wrong" one by accident, and
+nothing merges the two, so the same package can end up skipped from one
+angle and not the other depending on which block someone edits. Raises
+DuplicateConditionError (exit 1) rather than silently merging them, since
+merging by hand needs a human to reconcile any per-item comments correctly.
+
 Usage:
   vinca-sort-vinca-lists [FILE]
   vinca-sort-vinca-lists --check [FILE]
@@ -27,10 +36,17 @@ LISTS_TO_SORT = {
 RE_SIMPLE_ITEM = re.compile(r"^  - (\S.*)$")
 # Regex for the start of a conditional block: "  - if: ..."
 RE_IF_BLOCK = re.compile(r"^  - if:")
+# Regex capturing the condition text of a "  - if: <condition>" line
+RE_IF_CONDITION = re.compile(r"^  - if:\s*(.+?)\s*$")
 # Regex for a then-list item inside a conditional block: "      - value"
 RE_THEN_ITEM = re.compile(r"^      - (\S.*)$")
 # Regex for a top-level key
 RE_TOP_KEY = re.compile(r"^(\S+):")
+
+
+class DuplicateConditionError(ValueError):
+    """Raised when the same `- if:` condition appears in more than one block
+    under the same top-level list key."""
 
 
 def _sort_key(line: str) -> str:
@@ -57,6 +73,7 @@ def sort_vinca_lists(path: Path) -> bool:
         # Check if this line starts a target list key
         m = RE_TOP_KEY.match(line)
         if m and m.group(1) in LISTS_TO_SORT:
+            list_key = m.group(1)
             result.append(line)
             i += 1
 
@@ -135,6 +152,25 @@ def sort_vinca_lists(path: Path) -> bool:
             # Finalize any pending if-block
             if current_if_block is not None:
                 if_blocks.append(current_if_block)
+
+            # Reject duplicate conditions: two separate "- if:" blocks for the
+            # same condition under the same list key. See module docstring.
+            seen_conditions = {}
+            for block in if_blocks:
+                cond_match = RE_IF_CONDITION.match(block[0])
+                if not cond_match:
+                    continue
+                condition = cond_match.group(1)
+                if condition in seen_conditions:
+                    raise DuplicateConditionError(
+                        f"{list_key}: condition {condition!r} appears in more "
+                        f"than one '- if:' block. Merge them into a single "
+                        f"block (each item may need its own comment moved "
+                        f"inline first, since sorting the merged then: list "
+                        f"can otherwise separate a standalone comment from "
+                        f"the item it was meant to describe)."
+                    )
+                seen_conditions[condition] = True
 
             # Sort simple items
             sorted_simple = sorted(simple_items, key=_sort_key)
@@ -221,14 +257,20 @@ def main():
         print(f"ERROR: {args.file} not found", file=sys.stderr)
         sys.exit(1)
 
-    if args.check:
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tf:
-            tmp = Path(tf.name)
-        shutil.copy2(args.file, tmp)
-        changed = sort_vinca_lists(tmp)
-        tmp.unlink(missing_ok=True)
-    else:
-        changed = sort_vinca_lists(args.file)
+    try:
+        if args.check:
+            with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tf:
+                tmp = Path(tf.name)
+            shutil.copy2(args.file, tmp)
+            try:
+                changed = sort_vinca_lists(tmp)
+            finally:
+                tmp.unlink(missing_ok=True)
+        else:
+            changed = sort_vinca_lists(args.file)
+    except DuplicateConditionError as e:
+        print(f"ERROR: {args.file}: {e}", file=sys.stderr)
+        sys.exit(1)
 
     status = ("UNSORTED" if args.check else "SORTED") if changed else "OK"
     print(f"{status}: {args.file}")

--- a/vinca/test_sort_vinca_lists.py
+++ b/vinca/test_sort_vinca_lists.py
@@ -1,6 +1,8 @@
 """Tests for the vinca.yaml list sorter."""
 
-from vinca.sort_vinca_lists import sort_vinca_lists
+import pytest
+
+from vinca.sort_vinca_lists import DuplicateConditionError, sort_vinca_lists
 
 BASE = """packages_select_by_deps:
   - alpha
@@ -96,3 +98,64 @@ patch_dir: patch
     first_block, second_block = path.read_text().split("- if: linux and not aarch64")
     assert "- webots_ros2" not in first_block
     assert "- webots_ros2" in second_block
+
+
+def test_duplicate_condition_in_same_list_raises(tmp_path):
+    # Two non-adjacent "- if: win" blocks under the same list key, separated
+    # by unrelated content -- not the adjacency bug from the previous fix,
+    # just two blocks that should have been one all along.
+    content = """packages_select_by_deps:
+  - if: win
+    then:
+      - alpha
+
+  - unrelated_package
+
+  - if: win
+    then:
+      - bravo
+"""
+    path = tmp_path / "vinca.yaml"
+    path.write_text(content)
+
+    with pytest.raises(
+        DuplicateConditionError, match=r"packages_select_by_deps.*'win'"
+    ):
+        sort_vinca_lists(path)
+
+
+def test_duplicate_condition_scoped_per_list_key(tmp_path):
+    # The same condition appearing once in each of two different list keys
+    # is fine -- duplication is only a problem within a single list key.
+    content = """packages_skip_by_deps:
+  - if: win
+    then:
+      - alpha
+
+packages_select_by_deps:
+  - if: win
+    then:
+      - bravo
+"""
+    path = tmp_path / "vinca.yaml"
+    path.write_text(content)
+
+    # Should not raise.
+    sort_vinca_lists(path)
+
+
+def test_different_conditions_do_not_raise(tmp_path):
+    content = """packages_select_by_deps:
+  - if: win
+    then:
+      - alpha
+
+  - if: not win
+    then:
+      - bravo
+"""
+    path = tmp_path / "vinca.yaml"
+    path.write_text(content)
+
+    # Should not raise.
+    sort_vinca_lists(path)


### PR DESCRIPTION
## Summary

- Two "- if:" blocks for the same condition under one list key (e.g. two separate "if: win" blocks in `packages_select_by_deps`) are never wrong on their own, but they're a standing foot-gun downstream: a future addition can land in the "wrong" one by accident, nothing merges the two, and the same package can end up skipped from one angle and not the other depending on which block someone edits later.
- This is distinct from the adjacent-blocks bug fixed in #152 — these duplicates aren't adjacent, so that fix's "close the block on a new `- if:` line" logic never sees them as related at all.
- Raises `DuplicateConditionError` (exit 1, clean message naming the list key and condition) rather than silently merging the blocks — merging correctly needs a human to reconcile any per-item comments, since sorting the merged `then:` list can separate a standalone comment from the item it was meant to describe.

## Motivation

Found while auditing RoboStack/ros-humble, ros-jazzy, and ros-rolling's `vinca.yaml` files for exactly this pattern. Humble alone had accumulated 4 separate duplicate-condition groups across ~19 blocks (mostly `if: not win` and `if: linux`) from being extended incrementally across many sessions — consolidating them by hand also surfaced live cases where a per-item comment had already drifted onto the wrong package from a previous sort, which is what motivated making the check hard-fail rather than silently reformat.

## Test plan

- [x] `pytest vinca/` — all 236 tests pass (7 in `test_sort_vinca_lists.py`, including 3 new ones for this change: duplicate-in-same-list raises, duplicate-across-different-list-keys is fine, different-conditions-in-same-list is fine)
- [x] `ruff check` / `ruff format --check` clean
- [x] Ran the updated checker against the already-consolidated humble/jazzy/rolling `vinca.yaml` files — all pass clean with no duplicates
- [x] Verified against a synthetic non-adjacent duplicate (`- if: win` ... other content ... `- if: win`) that it's correctly caught with a clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)