### PR TITLE
fix: use explicit refs/tags/ in GitHub raw package.xml URLs

### DIFF
--- a/vinca/distro.py
+++ b/vinca/distro.py
@@ -543,12 +543,26 @@ class Distro(object):
         # Extract owner/repo
         owner_repo = raw_url_base.split("github.com/")[-1]
         # Use rev if available, otherwise fallback to tag
-        ref = pkg_info.get("rev") or pkg_info.get("tag")
+        rev = pkg_info.get("rev")
+        tag = pkg_info.get("tag")
         xml_name = pkg_info.get("package_xml_name", "package.xml")
         additional_folder = pkg_info.get("additional_folder", "")
         if additional_folder != "":
             additional_folder = additional_folder + "/"
-        raw_url = f"https://raw.githubusercontent.com/{owner_repo}/{ref}/{additional_folder}{xml_name}"
+        if rev:
+            # A commit hash is unambiguous as-is.
+            ref_path = rev
+        else:
+            # ros2-gbp release tags look like "release/jazzy/foo_pkg/1.2.3-1" --
+            # raw.githubusercontent.com's short <owner>/<repo>/<ref>/<path> form
+            # has to guess where a slash-containing ref ends and the path
+            # begins, and that guess is inconsistently cached across CDN edges:
+            # the same URL can 404 from some vantage points (including GitHub
+            # Actions runners) while resolving fine from others. The explicit
+            # refs/tags/<name> form removes the ambiguity and resolves
+            # reliably everywhere.
+            ref_path = f"refs/tags/{tag}"
+        raw_url = f"https://raw.githubusercontent.com/{owner_repo}/{ref_path}/{additional_folder}{xml_name}"
         return raw_url
 
     # format (checked against GitLab 19.x): https://gitlab.com/<NAMESPACE>/-/raw/<REV>/<PATH>

--- a/vinca/test_github_raw_url.py
+++ b/vinca/test_github_raw_url.py
@@ -1,0 +1,59 @@
+from typing import Any
+
+from vinca.distro import Distro
+
+
+def _distro() -> Any:
+    return Distro.__new__(Distro)
+
+
+def test_tag_ref_uses_explicit_refs_tags_prefix():
+    # ros2-gbp release tags look like "release/jazzy/foo_pkg/1.2.3-1" -- the
+    # short <owner>/<repo>/<ref>/<path> raw.githubusercontent.com form has to
+    # guess where a slash-containing ref ends and the path begins, and that
+    # guess is inconsistently cached across CDN edges (the same URL 404s from
+    # some vantage points, including GitHub Actions runners, while resolving
+    # fine from others). The explicit refs/tags/<name> form is unambiguous.
+    pkg_info = {
+        "url": "https://github.com/ros2-gbp/ros2_control-release.git",
+        "tag": "release/jazzy/controller_interface/4.47.0-1",
+    }
+
+    url = _distro()._construct_raw_url_github(pkg_info)
+
+    assert url == (
+        "https://raw.githubusercontent.com/ros2-gbp/ros2_control-release/"
+        "refs/tags/release/jazzy/controller_interface/4.47.0-1/package.xml"
+    )
+
+
+def test_rev_ref_is_used_as_is():
+    # A commit hash is already unambiguous -- it must not get the refs/tags/
+    # prefix, since it isn't a tag name.
+    pkg_info = {
+        "url": "https://github.com/ros2-gbp/ros2_control-release.git",
+        "rev": "abc123def456",
+    }
+
+    url = _distro()._construct_raw_url_github(pkg_info)
+
+    assert url == (
+        "https://raw.githubusercontent.com/ros2-gbp/ros2_control-release/"
+        "abc123def456/package.xml"
+    )
+
+
+def test_tag_ref_with_additional_folder_and_custom_xml_name():
+    pkg_info = {
+        "url": "https://github.com/example/some-release.git",
+        "tag": "release/rolling/some_pkg/1.0.0-1",
+        "additional_folder": "some_pkg",
+        "package_xml_name": "package.xml",
+    }
+
+    url = _distro()._construct_raw_url_github(pkg_info)
+
+    assert url == (
+        "https://raw.githubusercontent.com/example/some-release/"
+        "refs/tags/release/rolling/some_pkg/1.0.0-1/some_pkg/package.xml"
+    )

--- a/vinca/test_snapshot_metadata.py
+++ b/vinca/test_snapshot_metadata.py
@@ -61,9 +61,11 @@ def make_snapshot_distro(monkeypatch):
     distro._distro = Mock()
     snapshot_xml_by_url = {
         "https://raw.githubusercontent.com/example/snapshot-package-release/"
-        "release/rolling/snapshot_package/1.0.0-1/package.xml": (SNAPSHOT_PACKAGE_XML),
+        "refs/tags/release/rolling/snapshot_package/1.0.0-1/package.xml": (
+            SNAPSHOT_PACKAGE_XML
+        ),
         "https://raw.githubusercontent.com/example/snapshot-dependency-release/"
-        "release/rolling/snapshot_dependency/1.0.0-1/package.xml": (
+        "refs/tags/release/rolling/snapshot_dependency/1.0.0-1/package.xml": (
             SNAPSHOT_DEPENDENCY_XML
         ),
     }


### PR DESCRIPTION
## Summary
- ros2-gbp release tags look like `release/jazzy/foo_pkg/1.2.3-1` -- the short `raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>` form has to guess where a slash-containing ref ends and the path begins.
- That guess is inconsistently cached across CDN edges: the same URL 404s from some vantage points (including GitHub Actions runners) while resolving fine from others -- observed repeatedly and reproducibly as a persistent, non-transient failure on RoboStack/ros-jazzy CI (same exact package URL, same exact failure, across multiple runs over more than an hour, even after adding GitHub token auth).
- The explicit `refs/tags/<name>` form removes the ambiguity and resolves reliably everywhere. A commit hash (`rev`) is already unambiguous and is left as-is.

## Motivation
This was mistaken for a rate-limiting issue at first (GitHub's raw content requests were unauthenticated), but adding auth didn't fix it. Directly comparing the two URL forms confirmed the ambiguous short form is the actual culprit.

## Test plan
- Added `vinca/test_github_raw_url.py` covering: tag ref gets the `refs/tags/` prefix, rev (commit hash) ref is left bare, and the additional-folder/custom-xml-name case still works with the prefix.
- Updated `vinca/test_snapshot_metadata.py`'s mocked URLs to match the new format (3 previously-passing tests hardcoded the old URL shape).
- Full suite: 236 passed.
- Verified the exact failing URL from CI resolves via `curl` in both forms, and confirmed via a real git clone that the tag's `package.xml` content is genuinely present and correct -- this was never a data/version issue, only a URL-ambiguity/CDN-caching one.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>